### PR TITLE
Try adding support for ignore modules by regular expression pattern

### DIFF
--- a/author/script/perlimports
+++ b/author/script/perlimports
@@ -70,6 +70,21 @@ to ignore. (See above for behaviour). The pattern is one module name per line.
     Foo
     Foo::Bar
 
+=head2 --ignore-modules-pattern
+
+A comma-separated list of module names which should be ignored by this script.
+Any modules in this list should remain unchanged after processing.
+
+    --ignore-modules '^(Foo|Foo::Bar)'
+
+=head2 --ignore-modules-pattern-filename
+
+The absolute or relative path to a file which contains a lost of module names
+to ignore. (See above for behaviour). The pattern is one module name per line.
+
+    ^Foo
+    ^Foo::Bar
+
 =head2 --never-export-modules
 
 A comma-separated list of module names which should never export symbols. If

--- a/author/script/perlimports
+++ b/author/script/perlimports
@@ -72,15 +72,17 @@ to ignore. (See above for behaviour). The pattern is one module name per line.
 
 =head2 --ignore-modules-pattern
 
-A comma-separated list of module names which should be ignored by this script.
-Any modules in this list should remain unchanged after processing.
+A regular expression that comma-separated list of module names which should be
+ignored by this script. Any modules matched by this regular expression remain
+unchanged after processing.
 
     --ignore-modules '^(Foo|Foo::Bar)'
 
 =head2 --ignore-modules-pattern-filename
 
-The absolute or relative path to a file which contains a lost of module names
-to ignore. (See above for behaviour). The pattern is one module name per line.
+The absolute or relative path to a file which contains a list of regular
+expression that matches modules that should be ignored. (See above for behaviour).
+The pattern is one regular expression per line.
 
     ^Foo
     ^Foo::Bar

--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -166,7 +166,9 @@ sub _build_ignore_modules {
 sub _build_ignore_modules_pattern {
     my $self = shift;
     my @ignore_modules_pattern
-        = $self->_opts->ignore_modules_pattern ? $self->_opts->ignore_modules_pattern : ();
+        = $self->_opts->ignore_modules_pattern
+        ? $self->_opts->ignore_modules_pattern
+        : ();
 
     if ( $self->_opts->ignore_modules_pattern_filename ) {
         my @from_file

--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -28,6 +28,13 @@ has _ignore_modules => (
     builder => '_build_ignore_modules',
 );
 
+has _ignore_modules_pattern => (
+    is      => 'ro',
+    isa     => ArrayRef,
+    lazy    => 1,
+    builder => '_build_ignore_modules_pattern',
+);
+
 has _never_exports => (
     is      => 'ro',
     isa     => ArrayRef,
@@ -64,6 +71,10 @@ sub _build_args {
             'ignore-modules=s',
             'Comma-separated list of modules to ignore.'
         ],
+        [
+            'ignore-modules-pattern=s',
+            'Regular expression that matches modules to ignore.'
+        ],
         [],
         [
             'cache!',
@@ -74,6 +85,10 @@ sub _build_args {
         [
             'ignore-modules-filename=s',
             'Path to file listing modules to ignore. One per line.'
+        ],
+        [
+            'ignore-modules-pattern-filename=s',
+            'Path to file listing regular expressions that matches modules to ignore. One per line.'
         ],
         [],
         [
@@ -148,6 +163,20 @@ sub _build_ignore_modules {
     return \@ignore_modules;
 }
 
+sub _build_ignore_modules_pattern {
+    my $self = shift;
+    my @ignore_modules_pattern
+        = $self->_opts->ignore_modules_pattern ? $self->_opts->ignore_modules_pattern : ();
+
+    if ( $self->_opts->ignore_modules_pattern_filename ) {
+        my @from_file
+            = path( $self->_opts->ignore_modules_pattern_filename )
+            ->lines( { chomp => 1 } );
+        @ignore_modules_pattern = uniq( @ignore_modules_pattern, @from_file );
+    }
+    return \@ignore_modules_pattern;
+}
+
 sub _build_never_exports {
     my $self = shift;
 
@@ -215,6 +244,9 @@ sub run {
                 filename => $opts->filename,
                 @{ $self->_ignore_modules }
                 ? ( ignore_modules => $self->_ignore_modules )
+                : (),
+                @{ $self->_ignore_modules_pattern }
+                ? ( ignore_modules_pattern => $self->_ignore_modules_pattern )
                 : (),
                 @{ $self->_never_exports }
                 ? ( never_export_modules => $self->_never_exports )

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -8,7 +8,7 @@ our $VERSION = '0.000009';
 use App::perlimports::Annotations ();
 use App::perlimports::Include     ();
 use File::Basename qw( fileparse );
-use List::Util qw( any uniq );
+use List::Util qw( any uniq);
 use Module::Runtime qw( module_notional_filename );
 use MooX::StrictConstructor;
 use Path::Tiny qw( path );
@@ -59,6 +59,13 @@ has _ignore_modules => (
     isa      => HashRef,
     init_arg => 'ignore_modules',
     default  => sub { +{} },
+);
+
+has _ignore_modules_pattern => (
+    is       => 'ro',
+    isa      => ArrayRef [Str],
+    init_arg => 'ignore_modules_pattern',
+    default  => sub { [] },
 );
 
 has includes => (
@@ -658,10 +665,12 @@ sub _is_ignored {
     my $self    = shift;
     my $element = shift;
 
-    return
+    my $res =
            exists $default_ignore{ $element->module }
         || exists $self->_ignore_modules->{ $element->module }
-        || $self->_annotations->is_ignored($element);
+        || $self->_annotations->is_ignored($element)
+        || any { $element->module =~ /$_/ } grep { $_ } @{ $self->_ignore_modules_pattern || [] };
+    return $res;
 }
 
 sub inspector_for {

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -8,7 +8,7 @@ our $VERSION = '0.000009';
 use App::perlimports::Annotations ();
 use App::perlimports::Include     ();
 use File::Basename qw( fileparse );
-use List::Util qw( any uniq);
+use List::Util qw( any uniq );
 use Module::Runtime qw( module_notional_filename );
 use MooX::StrictConstructor;
 use Path::Tiny qw( path );
@@ -665,11 +665,12 @@ sub _is_ignored {
     my $self    = shift;
     my $element = shift;
 
-    my $res =
-           exists $default_ignore{ $element->module }
+    my $res
+        = exists $default_ignore{ $element->module }
         || exists $self->_ignore_modules->{ $element->module }
         || $self->_annotations->is_ignored($element)
-        || any { $element->module =~ /$_/ } grep { $_ } @{ $self->_ignore_modules_pattern || [] };
+        || any { $element->module =~ /$_/ }
+    grep { $_ } @{ $self->_ignore_modules_pattern || [] };
     return $res;
 }
 

--- a/t/cli.t
+++ b/t/cli.t
@@ -54,6 +54,31 @@ EOF
     is( $stdout, $expected, );
 };
 
+subtest '--ignore-modules-pattern' => sub {
+    my $expected = <<'EOF';
+use strict;
+use warnings;
+
+use Perl::Critic::Utils;
+
+my %foo = (
+    $QUOTE => q{description},
+);
+EOF
+
+    local @ARGV = (
+        '--ignore-modules-pattern',
+        '^Perl::.*',
+        '-f',
+        'test-data/var-in-hash-key.pl',
+    );
+    my $cli = App::perlimports::CLI->new;
+    my ($stdout) = capture {
+        $cli->run;
+    };
+    is( $stdout, $expected, );
+};
+
 subtest '--never-export-modules' => sub {
     my $expected = <<'EOF';
 use strict;


### PR DESCRIPTION
Hi, loved your talk at TPC 2021.

You asked for pull requests. Here's one for allowing ignoring modules by regex pattern. Should be useful for instance to not touch `use MyCompany::` lines, or perhaps using a pattern like `^Mo(use|o|ose\b`, like `^Test::` or similar.

Perhaps the ignore-modules-pattern-filename option is excessive given that one can combine regexps but just tried to follow the same approach as ignore-modules-*