### PR TITLE
Add a --[no-]tidy-whitespace param

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for App-perlimports
 
 {{$NEXT}}
+    - Add a --log-filename parameter (GH#37) (Olaf Alders)
+    - Add a --[no-]tidy-whitespace param (GH#38) (Olaf Alders)
+    - Fix disappearing module version numbers (GH#38) (Olaf Alders)
 
 0.000019  2021-09-17 19:20:44Z
     - Ignore modules with import errors (GH#35) (Olaf Alders)

--- a/author/script/perlimports
+++ b/author/script/perlimports
@@ -129,6 +129,17 @@ parentheses.
     # --no-padding
     use Foo qw(bar baz);
 
+=head2 --[no-]tidy-whitespace
+
+C<--tidy-whitespace> is enabled by default. This means that use statements will
+be updated even when the only change is in whitespace. Disabling this can help
+reduce the churn involved when running C<perlimports>, especially if the codebase
+does not have automated tidying.
+
+If you have changed from C<--padding> to C<--no-padding> or vice versa, you'll
+probably want to ensure that C<--tidy-whitespace> has also been enabled so that
+you can see the whitespace changes.
+
 =head2 --libs
 
 A comma separated list of module directories which are not in your C<@INC>

--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -132,6 +132,12 @@ sub _build_args {
             { default => 1 },
         ],
         [],
+        [
+            'tidy-whitespace!',
+            'reformat use statements even when changes are only whitespace',
+            { default => 1 },
+        ],
+        [],
         [],
         [ 'version', 'Print installed version', { shortcircuit => 1 } ],
         [

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -207,6 +207,14 @@ has tidied_document => (
     builder => '_build_tidied_document',
 );
 
+has _tidy_whitespace => (
+    is       => 'ro',
+    isa      => Bool,
+    init_arg => 'tidy_whitespace',
+    lazy     => 1,
+    default  => sub { 1 },
+);
+
 has _verbose => (
     is       => 'ro',
     isa      => Bool,
@@ -834,6 +842,7 @@ sub _build_tidied_document {
             logger           => $self->logger,
             original_imports => $self->original_imports->{ $include->module },
             pad_imports      => $self->_padding,
+            tidy_whitespace  => $self->_tidy_whitespace,
         );
         my $elem;
         try {

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -125,6 +125,14 @@ has _pad_imports => (
     default  => sub { 1 },
 );
 
+has _tidy_whitespace => (
+    is       => 'ro',
+    isa      => Bool,
+    init_arg => 'tidy_whitespace',
+    lazy     => 1,
+    default  => sub { 1 },
+);
+
 has _will_never_export => (
     is      => 'ro',
     isa     => Bool,
@@ -583,16 +591,17 @@ sub _maybe_get_new_include {
     my $doc       = PPI::Document->new( \$statement );
     my $includes
         = $doc->find( sub { $_[1]->isa('PPI::Statement::Include'); } );
-
-    my $check_string = $self->_include . q{};
-    $check_string =~ s{\s+}{ }g;
-
     my $rewrite = $includes->[0]->clone;
+
+    return $rewrite if $self->_tidy_whitespace;
 
     # If the only difference is spacing, we'll just return the original
     # statement rather than mess with the original formatting. This check is
     # naive, but should be good enough for now. It should reduce the churn
     # created by this script.
+    my $check_string = $self->_include . q{};
+    $check_string =~ s{\s+}{ }g;
+
     return ( "$rewrite" eq $check_string ) ? $self->_include : $rewrite;
 }
 

--- a/script/perlimports
+++ b/script/perlimports
@@ -588,6 +588,17 @@ parentheses.
     # --no-padding
     use Foo qw(bar baz);
 
+=head2 --[no-]tidy-whitespace
+
+C<--tidy-whitespace> is enabled by default. This means that use statements will
+be updated even when the only change is in whitespace. Disabling this can help
+reduce the churn involved when running C<perlimports>, especially if the codebase
+does not have automated tidying.
+
+If you have changed from C<--padding> to C<--no-padding> or vice versa, you'll
+probably want to ensure that C<--tidy-whitespace> has also been enabled so that
+you can see the whitespace changes.
+
 =head2 --libs
 
 A comma separated list of module directories which are not in your C<@INC>

--- a/t/config-in-import.pl
+++ b/t/config-in-import.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use App::perlimports::Document ();
-use Test::More;
+use Test::More import => [ 'done_testing', 'is' ];
 
 my $doc = App::perlimports::Document->new(
     filename => 'test-data/config-in-import.pl' );

--- a/t/fully-qualified.t
+++ b/t/fully-qualified.t
@@ -10,6 +10,7 @@ use Test::More import => [ 'done_testing', 'ok' ];
 my ($doc) = doc(
     filename        => 'test-data/fully-qualified.pl',
     preserve_unused => 0,
+    tidy_whitespace => 0,
 );
 
 ok( $doc->_is_used_fully_qualified('List::Util'), 'find List::Util' );

--- a/t/original-imports.pl
+++ b/t/original-imports.pl
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More import => [ 'done_testing', 'is_deeply' ];
 
 use App::perlimports::Document ();
 my $doc = App::perlimports::Document->new(

--- a/t/preserve-spaces.t
+++ b/t/preserve-spaces.t
@@ -5,16 +5,46 @@ use warnings;
 
 use lib 't/lib';
 
-use Test::More import => [ 'done_testing', 'is' ];
-use TestHelper qw( source2pi );
+use Test::Differences qw( eq_or_diff );
+use Test::More import => [ 'done_testing', 'subtest' ];
+use TestHelper qw( doc );
 
-my $source_text = 'use Carp    ();';
-my $e           = source2pi( 'test-data/preserve-spaces.pl', $source_text );
+subtest 'tidy_whitespace' => sub {
+    my $expected = <<'EOF';
+use strict;
+use warnings;
 
-is(
-    $e->formatted_ppi_statement,
-    $source_text,
-    'arbitrary spacing is preserved'
-);
+use Carp ();
+EOF
+    my ($doc) = doc(
+        filename        => 'test-data/preserve-spaces.pl',
+        tidy_whitespace => 1,
+    );
+
+    eq_or_diff(
+        $doc->tidied_document,
+        $expected,
+        'arbitrary spacing is preserved'
+    );
+};
+
+subtest 'disable tidy_whitespace' => sub {
+    my $expected = <<'EOF';
+use strict;
+use warnings;
+
+use Carp    ();
+EOF
+    my ($doc) = doc(
+        filename        => 'test-data/preserve-spaces.pl',
+        tidy_whitespace => 0,
+    );
+
+    eq_or_diff(
+        $doc->tidied_document,
+        $expected,
+        'arbitrary spacing is preserved'
+    );
+};
 
 done_testing();

--- a/t/with-version.t
+++ b/t/with-version.t
@@ -3,25 +3,39 @@ use warnings;
 
 use lib 't/lib';
 
-use TestHelper qw( source2pi );
-use Test::More import => [ 'done_testing', 'is', 'is_deeply', 'ok' ];
+use Test::Differences qw( eq_or_diff );
+use TestHelper qw( doc );
+use Test::More import => ['done_testing'];
 use Test::Needs qw( Cpanel::JSON::XS );
 
-my $e = source2pi(
-    'test-data/with-version.pl',
-    'use Getopt::Long 2.40 qw();',
-);
-is(
-    $e->module_name(), 'Getopt::Long',
-    'module_name'
+my ($doc) = doc( filename => 'test-data/with-version.pl' );
+
+my $expected = <<'EOF';
+use strict;
+use warnings;
+
+use Cpanel::JSON::XS 4.19 qw( decode_json );
+use Getopt::Long 2.40 qw( GetOptions );
+use LWP::UserAgent 6.49 ();
+use Test::Script 1.27 qw(
+    script_compiles
+    script_runs
+    script_stderr_is
+    script_stderr_like
 );
 
-ok( !$e->_is_ignored, '_is_ignored' );
-is_deeply( $e->_imports, ['GetOptions'], '_imports' );
-is(
-    $e->formatted_ppi_statement,
-    q{use Getopt::Long 2.40 qw( GetOptions );},
-    'formatted_ppi_statement'
+my $foo = decode_json( { foo => 'bar' } );
+my @foo = GetOptions();
+
+script_compiles();
+script_runs();
+script_stderr_is();
+script_stderr_like();
+EOF
+
+eq_or_diff(
+    $doc->tidied_document,
+    $expected
 );
 
 done_testing();

--- a/test-data/with-version.pl
+++ b/test-data/with-version.pl
@@ -4,6 +4,17 @@ use warnings;
 use Cpanel::JSON::XS 4.19 qw( encode_json );
 use Getopt::Long 2.40 qw();
 use LWP::UserAgent 6.49;
+use Test::Script 1.27 qw(
+    script_compiles
+    script_runs
+    script_stderr_is
+    script_stderr_like
+);
 
 my $foo = decode_json( { foo => 'bar' } );
 my @foo = GetOptions();
+
+script_compiles();
+script_runs();
+script_stderr_is();
+script_stderr_like();

--- a/tidyall.ini
+++ b/tidyall.ini
@@ -21,3 +21,23 @@ select = .stopwords
 [UniqueLines]
 select = .gitignore
 select = .stopwords
+
+[GenericTransformer perlimports]
+cmd = perl -Ilib script/perlimports
+argv = --libs lib,t/lib --no-preserve-duplicates --no-preserve-unused --log-filename /tmp/perlimports.txt --log-level debug
+file_flag = -f
+ok_exit_codes = 0
+weight = 1
+select = **/*.{pl,pm,t,psgi}
+ignore = .build/**/*
+ignore = App-perlimports-*/**/*
+ignore = blib/**/*
+ignore = fatlib/**/*
+ignore = inc/**/*
+ignore = t/00-*
+ignore = t/author-*
+ignore = t/release-*
+ignore = t/zzz-*
+ignore = test-data/**/*
+ignore = xt/**/*
+ignore = xt/author/{pod-coverage,pod-spell,tidyall}.t


### PR DESCRIPTION
- Add a --[no-]tidy-whitespace param
- Run perlimports on more files
- Fix bug where version number disappeared
- Add perlimports to tidyall config as GenericTransformer
