### PR TITLE
Eval import() statements before changing them

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for App-perlimports
 
 {{$NEXT}}
+    - Make package names which are used internally more random.
 
 0.000022  2021-09-27 01:31:43Z
     - Ensure PPI 1.270 is required in cpanfile (Reported by Slaven Rezić in

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -8,6 +8,7 @@ our $VERSION = '0.000023';
 use App::perlimports::Annotations     ();
 use App::perlimports::ExportInspector ();
 use App::perlimports::Include         ();
+use App::perlimports::Sandbox         ();
 use File::Basename qw( fileparse );
 use List::Util qw( any uniq );
 use Module::Runtime qw( module_notional_filename );
@@ -872,6 +873,18 @@ sub _build_tidied_document {
                 $self->_remove_with_trailing_characters($include);
                 next;
             }
+        }
+
+        # Let's see if the import itself might break something
+        if ( my $err
+            = App::perlimports::Sandbox::eval_pkg( $elem->module, "$elem" ) )
+        {
+            $self->logger->warning(
+                sprintf(
+                    'New include (%s) triggers error (%s)', $elem, $err
+                )
+            );
+            next;
         }
 
         # https://github.com/Perl-Critic/PPI/issues/189

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -88,7 +88,6 @@ has _isa_test_builder_module => (
     is      => 'ro',
     isa     => Bool,
     lazy    => 1,
-    builder => '_build_isa_test_builder_module',
     default => sub { shift->_export_inspector->isa_test_builder },
 );
 

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -212,6 +212,14 @@ sub _build_imports {
         my @found_import;
         my $isa_symbol = $word->isa('PPI::Token::Symbol');
 
+        # Don't confuse my @Foo with a use of @Foo which is exported by a module.
+        if ( $isa_symbol && $word->content =~ m{\A(@|%|$)} ) {
+            my $previous_sibling = $word->sprevious_sibling;
+            if ( $previous_sibling && $previous_sibling->content eq 'my' ) {
+                next;
+            }
+        }
+
         # If a module exports %foo and we find $foo{bar}, $word->canonical
         # returns $foo and $word->symbol returns %foo
         if (   $isa_symbol

--- a/lib/App/perlimports/Sandbox.pm
+++ b/lib/App/perlimports/Sandbox.pm
@@ -47,8 +47,13 @@ EOF
 
 # ABSTRACT: Internal Tools for perlimports
 
-=head1 pkg_for( $string )
+=head2 pkg_for( $string )
 
 Returns a random module/package name, which can be used to eval arbitrary code.
 Requires the name of the module which will be imported into the package to be
 created.
+
+=head2 eval_pkg( $module_name, $pkg_content )
+
+Takes a module name and content to eval. Returns the contents of C<$@>. So, if
+it returns true, the C<eval> failed.

--- a/lib/App/perlimports/Sandbox.pm
+++ b/lib/App/perlimports/Sandbox.pm
@@ -1,0 +1,34 @@
+package App::perlimports::Sandbox;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.000023';
+
+use Data::UUID ();
+
+{
+    my $du = Data::UUID->new;
+
+    sub pkg_for {
+        my $module_name = shift;
+        my $unique      = 'A' . $du->create_str;
+        $unique =~ s{-}{}g;
+
+        return sprintf(
+            'Local::%s::%s',
+            $module_name,
+            $unique
+        );
+    }
+}
+
+1;
+
+# ABSTRACT: Internal Tools for perlimports
+
+=head1 pkg_for( $string )
+
+Returns a random module/package name, which can be used to eval arbitrary code.
+Requires the name of the module which will be imported into the package to be
+created.

--- a/lib/App/perlimports/Sandbox.pm
+++ b/lib/App/perlimports/Sandbox.pm
@@ -23,6 +23,26 @@ use Data::UUID ();
     }
 }
 
+sub eval_pkg {
+    my $module_name = shift;
+    my $content     = shift;
+
+    my $pkg = pkg_for($module_name);
+
+    my $to_eval = <<"EOF";
+package $pkg;
+$content;
+1;
+EOF
+
+    local $@;
+    ## no critic (BuiltinFunctions::ProhibitStringyEval)
+    eval $to_eval;
+
+    my $e = $@;
+    return $e;
+}
+
 1;
 
 # ABSTRACT: Internal Tools for perlimports

--- a/t/Sandbox.t
+++ b/t/Sandbox.t
@@ -12,4 +12,22 @@ ok( $pkg2, 'second pkg' );
 
 cmp_ok( $pkg1, 'ne', $pkg2, 'names are not the same' );
 
+{
+    my $eval = App::perlimports::Sandbox::eval_pkg(
+        'Carp',
+        'use Carp qw( croak );',
+    );
+
+    ok( !$eval, 'no problems with eval' );
+}
+
+{
+    my $eval = App::perlimports::Sandbox::eval_pkg(
+        'Carp',
+        'use Local::ZZZ::XXX ();',
+    );
+
+    ok( $eval, 'could not eval' );
+}
+
 done_testing();

--- a/t/Sandbox.t
+++ b/t/Sandbox.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+
+use App::perlimports::Sandbox ();
+use Test::More import => [ 'cmp_ok', 'done_testing', 'ok' ];
+
+my $pkg1 = App::perlimports::Sandbox::pkg_for('fakeblock');
+my $pkg2 = App::perlimports::Sandbox::pkg_for('fakeblock');
+
+ok( $pkg1, 'first pkg' );
+ok( $pkg2, 'second pkg' );
+
+cmp_ok( $pkg1, 'ne', $pkg2, 'names are not the same' );
+
+done_testing();

--- a/t/Sandbox.t
+++ b/t/Sandbox.t
@@ -1,8 +1,12 @@
 use strict;
 use warnings;
 
+use lib 't/lib', 'test-data/lib';
+
 use App::perlimports::Sandbox ();
-use Test::More import => [ 'cmp_ok', 'done_testing', 'ok' ];
+use TestHelper qw( doc );
+use Test::Differences qw( eq_or_diff );
+use Test::More import => [ 'cmp_ok', 'done_testing', 'ok', 'subtest' ];
 
 my $pkg1 = App::perlimports::Sandbox::pkg_for('fakeblock');
 my $pkg2 = App::perlimports::Sandbox::pkg_for('fakeblock');
@@ -12,22 +16,60 @@ ok( $pkg2, 'second pkg' );
 
 cmp_ok( $pkg1, 'ne', $pkg2, 'names are not the same' );
 
-{
+subtest 'Carp' => sub {
     my $eval = App::perlimports::Sandbox::eval_pkg(
         'Carp',
         'use Carp qw( croak );',
     );
 
     ok( !$eval, 'no problems with eval' );
-}
+};
 
-{
+subtest 'missing module' => sub {
     my $eval = App::perlimports::Sandbox::eval_pkg(
-        'Carp',
+        'Local::ZZZ::XXX',
         'use Local::ZZZ::XXX ();',
     );
 
-    ok( $eval, 'could not eval' );
-}
+    ok( $eval, 'eval failure' );
+};
+
+subtest 'local module' => sub {
+    my $eval = App::perlimports::Sandbox::eval_pkg(
+        'Local::ImportException',
+        'use Local::ImportException ();',
+    );
+
+    ok( !$eval, 'no eval failure' );
+};
+
+subtest 'local module with exception' => sub {
+    my $eval = App::perlimports::Sandbox::eval_pkg(
+        'Local::ImportException',
+        'use Local::ImportException qw( exceptional );',
+    );
+
+    ok( $eval, 'eval failure' );
+};
+
+subtest 'eval in tidied_document' => sub {
+    my ($doc) = doc( filename => 'test-data/exceptional.pl' );
+
+    my $expected = <<'EOF';
+use strict;
+use warnings;
+
+use Carp qw( croak );
+use Local::ImportException;
+
+exceptional();
+croak();
+EOF
+
+    eq_or_diff(
+        $doc->tidied_document, $expected,
+        'does not update import with eval failure'
+    );
+};
 
 done_testing();

--- a/t/fully-qualified.t
+++ b/t/fully-qualified.t
@@ -6,6 +6,7 @@ use lib 't/lib';
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
 use Test::More import => [ 'diag', 'done_testing', 'ok' ];
+use Test::Needs qw( HTTP::Tiny );
 
 my ( $doc, $log ) = doc(
     filename        => 'test-data/fully-qualified.pl',

--- a/t/fully-qualified.t
+++ b/t/fully-qualified.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use lib 't/lib';
+use lib 't/lib', 'test-data/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );

--- a/t/fully-qualified.t
+++ b/t/fully-qualified.t
@@ -5,9 +5,9 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'ok' ];
+use Test::More import => [ 'diag', 'done_testing', 'ok' ];
 
-my ($doc) = doc(
+my ( $doc, $log ) = doc(
     filename        => 'test-data/fully-qualified.pl',
     preserve_unused => 0,
     tidy_whitespace => 0,
@@ -51,6 +51,8 @@ sub also_ok {
     return %Local::ViaExporter::foo;
 }
 EOF
-eq_or_diff( $doc->tidied_document, $expected, 'used modules not removed' );
+
+eq_or_diff( $doc->tidied_document, $expected, 'used modules not removed' )
+    || do { require Data::Dumper; diag Data::Dumper::Dumper($log); };
 
 done_testing;

--- a/t/with-version.t
+++ b/t/with-version.t
@@ -5,10 +5,10 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => ['done_testing'];
-use Test::Needs qw( Cpanel::JSON::XS );
+use Test::More import => [ 'diag', 'done_testing' ];
+use Test::Needs qw( Cpanel::JSON::XS LWP::UserAgent );
 
-my ($doc) = doc( filename => 'test-data/with-version.pl' );
+my ( $doc, $log ) = doc( filename => 'test-data/with-version.pl' );
 
 my $expected = <<'EOF';
 use strict;
@@ -16,7 +16,7 @@ use warnings;
 
 use Cpanel::JSON::XS 4.19 qw( decode_json );
 use Getopt::Long 2.40 qw( GetOptions );
-use LWP::UserAgent 6.49 ();
+use LWP::UserAgent 5.00 ();
 use Test::Script 1.27 qw(
     script_compiles
     script_runs
@@ -35,7 +35,8 @@ EOF
 
 eq_or_diff(
     $doc->tidied_document,
-    $expected
-);
+    $expected,
+    'versions preserved'
+) || do { require Data::Dumper; diag Data::Dumper::Dumper($log); };
 
 done_testing();

--- a/test-data/exceptional.pl
+++ b/test-data/exceptional.pl
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+
+use Carp;
+use Local::ImportException;
+
+exceptional();
+croak();

--- a/test-data/lib/Local/ImportException.pm
+++ b/test-data/lib/Local/ImportException.pm
@@ -1,0 +1,20 @@
+package Local::ImportException;
+
+use strict;
+use warnings;
+
+require Exporter;
+our @ISA       = qw( Exporter );
+our @EXPORT_OK = qw( exceptional );
+
+sub import {
+    my $pkg       = shift;
+    my $first_arg = shift;
+    if ( $first_arg && $first_arg eq 'exceptional' ) {
+        die 'oof';
+    }
+}
+
+sub exceptional { }
+
+1;

--- a/test-data/with-version.pl
+++ b/test-data/with-version.pl
@@ -3,7 +3,7 @@ use warnings;
 
 use Cpanel::JSON::XS 4.19 qw( encode_json );
 use Getopt::Long 2.40 qw();
-use LWP::UserAgent 6.49;
+use LWP::UserAgent 5.00;
 use Test::Script 1.27 qw(
     script_compiles
     script_runs


### PR DESCRIPTION
- Make package names which are used internally more random
- Add eval_pkg() to sandbox
- Eval import() statements before changing them
