### PR TITLE
Require a specific version of module with Test::Needs

### DIFF
--- a/t/with-version.t
+++ b/t/with-version.t
@@ -6,7 +6,10 @@ use lib 't/lib';
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
 use Test::More import => [ 'diag', 'done_testing' ];
-use Test::Needs qw( Cpanel::JSON::XS LWP::UserAgent );
+use Test::Needs {
+    'Cpanel::JSON::XS' => 4.19,
+    'LWP::UserAgent'   => 5.00,
+};
 
 my ( $doc, $log ) = doc( filename => 'test-data/with-version.pl' );
 

--- a/test-needs-cpanfile
+++ b/test-needs-cpanfile
@@ -2,17 +2,18 @@ use strict;
 use warnings;
 
 on 'test' => sub {
+    requires 'Cpanel::JSON::XS' => '4.19';
     requires 'DateTime' => 0;
     requires 'File::chdir' => 0;
     requires 'File::Spec::Functions' => 0;
     requires 'Geo::IP' => 0;
-    requires "Getopt::Long" => "2.40";
+    requires 'Getopt::Long' => '2.40';
     requires 'HTML::TableExtract' => 0;
     requires 'Import::Into' => 0;
     requires 'IP::Random' => '1.200230' if "$]" >= 5.020;
     requires 'Lingua::EN::Inflect';
     requires 'List::AllUtils' => 0;
-    requires "LWP::UserAgent" => "6.49";
+    requires 'LWP::UserAgent' => '6.49';
     requires 'MetaCPAN::Moose' => 0;
     requires 'Mojo' => 0 if "$]" >= 5.016000;
     requires 'Moose' => 0;


### PR DESCRIPTION
In this case, since the module version is included in the use statement,
we need to ensure that the minimum version has also been installed. If
it hasn't, we won't be able to eval the statement and the original
statement will remain unchanged, causing t/with-version.t to fail

Fixes #41
