### PR TITLE
Allow module name to be passed to dump-perl-exports without flag

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for App-perlimports
 
 {{$NEXT}}
     - Ignore Env.pm for the time being
+    - Ignore Constant::Generate and Git::Sub
 
 0.000025  2021-10-13 21:42:40Z
     - Add another minimum version to t/with-version.t (GH#43) (Olaf Alders)

--- a/Changes
+++ b/Changes
@@ -1,8 +1,10 @@
 Revision history for App-perlimports
 
 {{$NEXT}}
-    - Ignore Env.pm for the time being
-    - Ignore Constant::Generate and Git::Sub
+    - Ignore Env.pm for the time being (GH#47) (Olaf Alders)
+    - Allow module name to be passed to dump-perl-exports without flag (GH#46) (Olaf Alders)
+    - Ignore Constant::Generate and Git::Sub (GH#46) (Olaf Alders)
+    - Bump minimum Perl to 5.12.0 (GH#46) (Olaf Alders)
 
 0.000025  2021-10-13 21:42:40Z
     - Add another minimum version to t/with-version.t (GH#43) (Olaf Alders)

--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,7 @@ phase = build
 [Prereqs / RuntimeRequires]
 Class::Inspector = 1.36
 Log::Dispatch = 2.70
+perl = 5.12.0
 Perl::Tidy = 20210402
 PPI = 1.270
 Symbol::Get = 0.10

--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -235,7 +235,8 @@ sub run {
         ? $self->logger
         : Log::Dispatch->new(
         outputs => [
-            $opts->log_filename ? [
+            $opts->log_filename
+            ? [
                 'File',
                 binmode   => ':encoding(UTF-8)',
                 filename  => $opts->log_filename,

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -241,6 +241,7 @@ around BUILDARGS => sub {
 
 my %default_ignore = (
     'Carp::Always'                   => 1,
+    'Constant::Generate'             => 1,
     'Data::Printer'                  => 1,
     'DDP'                            => 1,
     'Devel::Confess'                 => 1,
@@ -250,6 +251,7 @@ my %default_ignore = (
     'Exporter'                       => 1,
     'Exporter::Lite'                 => 1,
     'Feature::Compat::Try'           => 1,
+    'Git::Sub'                       => 1,
     'HTTP::Message::PSGI'            => 1,    # HTTP::Request::(to|from)_psgi
     'Mojo::Base'                     => 1,
     'Mojo::Date'                     => 1,

--- a/script/dump-perl-exports
+++ b/script/dump-perl-exports
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use feature qw( say );
 
 use App::perlimports::ExportInspector ();
 use Getopt::Long::Descriptive qw( describe_options );
@@ -12,14 +13,20 @@ use Pod::Usage qw( pod2usage );
 use Text::SimpleTable::AutoWidth ();
 
 my ( $opts, $usage ) = _options();
-( print $App::perlimports::ExportInspector::VERSION ) && exit
-    if $opts->version;
-( print $usage ) && exit if $opts->help;
+
+if ( $opts->version ) {
+    say $App::perlimports::ExportInspector::VERSION;
+    exit(0);
+}
+
+if ( $opts->help ) {
+    print $usage;
+    exit(0);
+}
 
 if ( $opts->verbose_help ) {
-    print $usage;
-    print pod2usage();
-    exit;
+    print STDOUT $usage;
+    pod2usage({ -exitval => 0 });
 }
 
 if ( $opts->libs ) {
@@ -37,9 +44,17 @@ my $logger = Log::Dispatch->new(
     ]
 );
 
+my $module = $opts->module || shift @ARGV;
+
+if ( !$module ) {
+    say q{Mandatory parameter 'module' missing};
+    print $usage;
+    exit(1);
+}
+
 my $ei = App::perlimports::ExportInspector->new(
     logger      => $logger,
-    module_name => $opts->module,
+    module_name => $module,
 );
 
 if ( $ei->is_oo_class ) {
@@ -148,7 +163,6 @@ sub _options {
         'dump-perl-exports %o',
         [
             'module|m=s', 'The module to inspect for exports',
-            { required => 1 }
         ],
         [],
         [

--- a/t/dump-perl-exports.t
+++ b/t/dump-perl-exports.t
@@ -24,6 +24,44 @@ subtest 'Moo' => sub {
     script_stderr_is( q{}, 'no errors' );
 };
 
+subtest 'implied --module' => sub {
+    script_runs( [ 'script/dump-perl-exports', 'Moo' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+subtest 'help' => sub {
+    script_runs( [ 'script/dump-perl-exports', '--help' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+subtest 'libs' => sub {
+    script_runs(
+        [
+            'script/dump-perl-exports',
+            '--libs',
+            'test-data/lib',
+            'Local::ViaExporter'
+        ]
+    );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+subtest 'log level' => sub {
+    script_runs(
+        [ 'script/dump-perl-exports', '--log-level', 'info', 'Moo' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+subtest 'verbose help' => sub {
+    script_runs( [ 'script/dump-perl-exports', '--verbose-help' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+subtest 'version' => sub {
+    script_runs( [ 'script/dump-perl-exports', '--version' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
 subtest 'Local::ViaExporter' => sub {
     script_runs(
         [


### PR DESCRIPTION
- Ignore Constant::Generate and Git::Sub
- Allow module name to be passed to dump-perl-exports without flag
- Bump minimum Perl to 5.12.0
