### PR TITLE
perlimports now assumes the first thing remaining in \@ARGV is a filename

### DIFF
--- a/author/script/perlimports
+++ b/author/script/perlimports
@@ -17,7 +17,11 @@ exit(0);
 
 Update a file in place. (Make sure you can revert the file if you need to.)
 
-    perlimports --filename test-data/foo.pl --inplace-edit
+    perlimports -i test-data/foo.pl
+
+Run C<perlimports> on a file and print the results to STDOUT.
+
+    perlimports test-data/foo.pl
 
 If some of your imported modules are in local directories, you can give some
 hints as to where to find them:
@@ -260,6 +264,15 @@ The absolute or relative path to a file to process.
     --filename path/to/file
 
     -f path/to/file
+
+Note that if you do not provide a C<--filename> we will fall back to checking
+C<@ARGV> for any remaining args. So,
+
+    perlimports --filename path/to/file
+
+is equivalent to
+
+    perlimports path/to/file
 
 =head2 --ignore-modules
 

--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -2,6 +2,7 @@ package App::perlimports::CLI;
 
 use Moo;
 use utf8;
+use feature qw( say );
 
 our $VERSION = '0.000026';
 
@@ -62,10 +63,7 @@ sub _build_args {
     my $self = shift;
     my ( $opt, $usage ) = describe_options(
         'perlimports %o',
-        [
-            'filename|f=s', 'The file containing the imports',
-            { required => 1 }
-        ],
+        [ 'filename|f=s', 'The file containing the imports' ],
         [],
         [
             'ignore-modules=s',
@@ -254,7 +252,20 @@ sub run {
         ]
         );
 
-    $logger->notice( '🚀 Starting file: ' . $opts->filename );
+    my $filename = $opts->filename || shift @ARGV;
+    if ( !$filename ) {
+        say STDERR q{Mandatory parameter 'filename' missing};
+        print STDERR $self->_usage->text;
+        exit(1);
+    }
+
+    if ( !path($filename)->is_file ) {
+        say STDERR "$filename does not appear to be a file";
+        print STDERR $self->_usage->text;
+        exit(1);
+    }
+
+    $logger->notice( '🚀 Starting file: ' . $filename );
 
     # Capture STDOUT here so that 3rd party code printing to STDOUT doesn't get
     # piped back into vim.
@@ -262,7 +273,7 @@ sub run {
         sub {
             my $pi_doc = App::perlimports::Document->new(
                 cache    => $opts->cache,
-                filename => $opts->filename,
+                filename => $filename,
                 @{ $self->_ignore_modules }
                 ? ( ignore_modules => $self->_ignore_modules )
                 : (),
@@ -289,7 +300,7 @@ sub run {
     elsif ( $opts->inplace_edit ) {
 
         # append() with truncate, because spew() can change file permissions
-        path( $opts->filename )->append( { truncate => 1 }, $tidied );
+        path($filename)->append( { truncate => 1 }, $tidied );
     }
     else {
         print $tidied;

--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -215,7 +215,7 @@ sub run {
     if ( $opts->verbose_help ) {
         print $self->_usage->text;
         require Pod::Usage;    ## no perlimports
-        print Pod::Usage::pod2usage();
+        Pod::Usage::pod2usage( ( { -exitval => 0 } ) );
         return;
     }
 

--- a/t/perlimports.t
+++ b/t/perlimports.t
@@ -7,6 +7,7 @@ use Test::More import => [ 'done_testing', 'subtest' ];
 use Test::Needs qw( Moose );
 use Test::Script 1.27 qw(
     script_compiles
+    script_fails
     script_runs
     script_stderr_is
     script_stderr_like
@@ -22,10 +23,10 @@ subtest 'filename' => sub {
     script_stderr_is( q{}, 'no errors' );
 };
 
-#subtest 'implied --filename' => sub {
-#script_runs( [ $script, 'Moo' ] );
-#script_stderr_is( q{}, 'no errors' );
-#};
+subtest 'implied --filename' => sub {
+    script_runs( [ $script, 'test-data/carp.pl' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
 
 subtest 'help' => sub {
     script_runs( [ $script, '--help' ] );
@@ -65,13 +66,17 @@ subtest 'version' => sub {
     script_stderr_is( q{}, 'no errors' );
 };
 
-#subtest 'Not Found' => sub {
-#script_runs(
-#[
-#'script/perlimports', '--filename', 'x',
-#]
-#);
-#script_stderr_like( qr{Can't locate}, 'error when module not found' );
-#};
+subtest 'Not Found' => sub {
+    script_fails(
+        [
+            'script/perlimports', '--filename', 'x',
+        ],
+        { exit => 1 }
+    );
+    script_stderr_like(
+        qr{x does not appear to be a file},
+        'error when module not found'
+    );
+};
 
 done_testing();

--- a/t/perlimports.t
+++ b/t/perlimports.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More import => [ 'done_testing', 'subtest' ];
+use Test::Needs qw( Moose );
+use Test::Script 1.27 qw(
+    script_compiles
+    script_runs
+    script_stderr_is
+    script_stderr_like
+);
+
+script_compiles('script/perlimports');
+
+my $script   = 'script/perlimports';
+my @filename = ( '--filename', 'test-data/carp.pl' );
+
+subtest 'filename' => sub {
+    script_runs( [ $script, @filename ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+#subtest 'implied --filename' => sub {
+#script_runs( [ $script, 'Moo' ] );
+#script_stderr_is( q{}, 'no errors' );
+#};
+
+subtest 'help' => sub {
+    script_runs( [ $script, '--help' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+subtest 'libs' => sub {
+    script_runs(
+        [
+            $script,
+            '--libs',
+            'test-data/lib',
+            '--filename',
+            'test-data/lib/Local/ViaExporter.pm',
+        ]
+    );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+subtest 'log level' => sub {
+    script_runs( [ $script, @filename, '--log-level', 'info', ] );
+    script_stderr_like( qr{Starting file: test-data/carp.pl}, 'no errors' );
+};
+
+subtest 'help' => sub {
+    script_runs( [ 'script/perlimports', '--help' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+subtest 'verbose help' => sub {
+    script_runs( [ 'script/perlimports', '--verbose-help' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+subtest 'version' => sub {
+    script_runs( [ $script, '--version' ] );
+    script_stderr_is( q{}, 'no errors' );
+};
+
+#subtest 'Not Found' => sub {
+#script_runs(
+#[
+#'script/perlimports', '--filename', 'x',
+#]
+#);
+#script_stderr_like( qr{Can't locate}, 'error when module not found' );
+#};
+
+done_testing();


### PR DESCRIPTION
- Print perlimports --verbose-help to STDOUT
- Add some script tests for perlimports
- perlimports now assumes the first thing remaining in @ARGV is a filename
