### PR TITLE
Maintain stable sort order for lists which include sigils

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for App-perlimports
 
 {{$NEXT}}
+    - Maintain stable sort order for lists which include sigils (GH#57) (Olaf
+      Alders)
 
 0.000027  2021-11-29 22:29:05Z
     - Detect Test::Builder objects used in import() (GH#56) (Olaf Alders)

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -166,10 +166,8 @@ sub _build_imports {
 
     my %found;
 
-    print 'xxx',  "\n";
     # Stolen from Perl::Critic::Policy::TooMuchCode::ProhibitUnfoundImport
     for my $word ( @{ $self->_document->possible_imports } ) {
-        print "$word\n";
         next if exists $found{"$word"};
 
         # No need to keep looking if we've found everything that can be
@@ -371,9 +369,7 @@ sub _build_imports {
         }
     }
 
-    @found = uniq $self->_sort_symbols( @found );
-    use DDP;
-    p @found;
+    @found = uniq $self->_sort_symbols(@found);
     if ( $self->_original_imports ) {
         my @preserved = grep { m{\A[!_]} } @{ $self->_original_imports };
         @found = uniq( @preserved, @found );
@@ -680,9 +676,19 @@ sub _sort_symbols {
     } @list;
 }
 
+# This looks a little weird, but basically we want to maintain a stable sort
+# order with lists that look like (foo, $foo, @foo, %foo).
 sub _transform_before_cmp {
     my $thing = shift;
-    $thing =~ s{\A[^\w]+}{};
+    if ( $thing =~ m{\A[\$]} ) {
+        $thing = substr( $thing, 1 ) . '_A';
+    }
+    elsif ( $thing =~ m{\A[@]} ) {
+        $thing = substr( $thing, 1 ) . '_B';
+    }
+    elsif ( $thing =~ m{\A[%]} ) {
+        $thing = substr( $thing, 1 ) . '_C';
+    }
     return $thing;
 }
 

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -166,8 +166,10 @@ sub _build_imports {
 
     my %found;
 
+    print 'xxx',  "\n";
     # Stolen from Perl::Critic::Policy::TooMuchCode::ProhibitUnfoundImport
     for my $word ( @{ $self->_document->possible_imports } ) {
+        print "$word\n";
         next if exists $found{"$word"};
 
         # No need to keep looking if we've found everything that can be
@@ -369,7 +371,9 @@ sub _build_imports {
         }
     }
 
-    @found = uniq sort { "\L$a" cmp "\L$b" } @found;
+    @found = uniq $self->_sort_symbols( @found );
+    use DDP;
+    p @found;
     if ( $self->_original_imports ) {
         my @preserved = grep { m{\A[!_]} } @{ $self->_original_imports };
         @found = uniq( @preserved, @found );
@@ -663,6 +667,23 @@ sub _is_already_imported {
     }
 
     return $duplicate;
+}
+
+sub _sort_symbols {
+    my $self = shift;
+    my @list = @_;
+
+    my @sorted = sort {
+        my $A = _transform_before_cmp($a);
+        my $B = _transform_before_cmp($b);
+        "\L$A" cmp "\L$B";
+    } @list;
+}
+
+sub _transform_before_cmp {
+    my $thing = shift;
+    $thing =~ s{\A[^\w]+}{};
+    return $thing;
 }
 
 1;

--- a/t/exported-variables.t
+++ b/t/exported-variables.t
@@ -32,7 +32,7 @@ ok( !$pi->_is_ignored, '_is_ignored' );
 
 is(
     $pi->formatted_ppi_statement,
-    q{use Local::ViaExporter qw( $foo %foo @foo );},
+    q{use Local::ViaExporter qw( $foo @foo %foo );},
     'formatted_ppi_statement'
 );
 

--- a/t/hash-in-regex.t
+++ b/t/hash-in-regex.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ '$TODO', 'done_testing', 'is' ];
+use Test::More import => [ 'done_testing', 'is', '$TODO' ];
 
 my ($doc) = doc( filename => 'test-data/hash-in-regex.pl' );
 my $expected = <<'EOF';

--- a/t/module-with-inner-packages.t
+++ b/t/module-with-inner-packages.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ '$TODO', 'done_testing', 'is' ];
+use Test::More import => [ 'done_testing', 'is', '$TODO' ];
 
 my ($doc) = doc( filename => 'test-data/lib/Local/WithInnerPkg.pm' );
 my $expected = <<'EOF';

--- a/t/perl-imports.t
+++ b/t/perl-imports.t
@@ -83,10 +83,10 @@ subtest 'ViaExporter' => sub {
         'Found some _explicit_exports'
     );
     ok( !$e->_isa_test_builder_module, 'isa_test_builder_module' );
-    is_deeply( $e->_imports, [qw( $foo %foo @foo foo )], '_imports' );
+    is_deeply( $e->_imports, [qw( foo $foo @foo %foo )], '_imports' );
     is(
         $e->formatted_ppi_statement,
-        'use Local::ViaExporter qw( $foo %foo @foo foo );',
+        'use Local::ViaExporter qw( foo $foo @foo %foo );',
         'formatted_ppi_statement'
     );
 };

--- a/t/sort-imports.t
+++ b/t/sort-imports.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use lib 'test-data/lib';
+
+
+
+done_testiong();

--- a/t/sort-imports.t
+++ b/t/sort-imports.t
@@ -1,10 +1,27 @@
 use strict;
 use warnings;
 
-use Test::More;
+use lib 't/lib', 'test-data/lib';
 
-use lib 'test-data/lib';
+use Test::Differences qw( eq_or_diff );
+use TestHelper qw( doc );
+use Test::More import => ['done_testing'];
 
+my ( $doc, $log ) = doc( filename => 'test-data/sort.pl' );
 
+my $expected = <<'EOF';
+use strict;
+use warnings;
 
-done_testiong();
+use Local::Sort qw( $AAA bbb @BBB %CCC );
+
+bbb();
+
+if ( defined $AAA || scalar @BBB || keys %CCC ) {
+    print 'defined';
+}
+EOF
+
+eq_or_diff( $doc->tidied_document, $expected, 'sorted' );
+
+done_testing();

--- a/test-data/lib/Local/Sort.pm
+++ b/test-data/lib/Local/Sort.pm
@@ -1,0 +1,21 @@
+package Local::Sort;
+
+use strict;
+use warnings;
+
+use Exporter qw( import );
+
+our $AAA = 1;
+our @BBB = ();
+our %CCC = ();
+
+sub bbb { }
+
+our @EXPORT_OK = (
+    '$AAA',
+    'bbb',
+    '@BBB',
+    '%CCC',
+);
+
+1;

--- a/test-data/sort.pl
+++ b/test-data/sort.pl
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+
+use Local::Sort qw( bbb $AAA @BBB %CCC );
+
+bbb();
+
+if ( defined $AAA || scalar @BBB || keys %CCC ) {
+    print 'defined';
+}


### PR DESCRIPTION
- Ignore sigils when sorting imported symbols
- Maintain stable sort order for lists which include sigils
