### PR TITLE
Rework formatting of Test::Builder modules

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for App-perlimports
 
 {{$NEXT}}
     - Ignore PerlIO::gzip and Modern::Perl
+    - Rework formatting of Test::Builder modules (GH#61) (Olaf Alders)
 
 0.000030  2021-12-21 22:55:49Z
     - Avoid calling methods on undef variable (GH#59) (Olaf Alders)

--- a/t/Document.t
+++ b/t/Document.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'ok' ];
+use Test::More import => [qw( done_testing ok )];
 
 my ($doc) = doc( filename => 'test-data/original-imports.pl' );
 

--- a/t/ExportInspector/SubExporter.t
+++ b/t/ExportInspector/SubExporter.t
@@ -4,8 +4,7 @@ use warnings;
 use lib 't/lib', 'test-data/lib';
 
 use Test::Differences qw( eq_or_diff );
-use Test::More import =>
-    [ 'done_testing', 'is', 'is_deeply', 'ok', 'subtest' ];
+use Test::More import => [qw( done_testing is is_deeply ok subtest )];
 use TestHelper qw( inspector );
 use Test::Needs qw(
     Import::Into

--- a/t/ExportInspector/load.t
+++ b/t/ExportInspector/load.t
@@ -5,7 +5,7 @@ use lib 'test-data/lib', 't/lib';
 
 use App::perlimports::ExportInspector ();
 use TestHelper qw( logger );
-use Test::More import => [ 'done_testing', 'is_deeply', 'ok', 'subtest' ];
+use Test::More import => [qw( done_testing is_deeply ok subtest )];
 use Test::Needs qw( Import::Into Moose Test::Most );
 use Test::Warnings ();
 

--- a/t/Sandbox.t
+++ b/t/Sandbox.t
@@ -6,7 +6,7 @@ use lib 't/lib', 'test-data/lib';
 use App::perlimports::Sandbox ();
 use TestHelper qw( doc );
 use Test::Differences qw( eq_or_diff );
-use Test::More import => [ 'cmp_ok', 'done_testing', 'ok', 'subtest' ];
+use Test::More import => [qw( cmp_ok done_testing ok subtest )];
 
 my $pkg1 = App::perlimports::Sandbox::pkg_for('fakeblock');
 my $pkg2 = App::perlimports::Sandbox::pkg_for('fakeblock');

--- a/t/after.t
+++ b/t/after.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib', 'test-data/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( List::AllUtils );
 
 my ( $doc, $logs ) = doc(

--- a/t/annotations.t
+++ b/t/annotations.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use App::perlimports::Annotations ();
 use PPI::Document                 ();
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is', 'ok', 'subtest' ];
+use Test::More import => [qw( done_testing is ok subtest )];
 
 subtest 'mixed' => sub {
     my $doc = PPI::Document->new( 'test-data/annotation.pl', readonly => 1, );

--- a/t/args-in-import.t
+++ b/t/args-in-import.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is_deeply' ];
+use Test::More import => [qw( done_testing is_deeply )];
 use Test::Needs qw( Test2::V0 );
 
 my ($doc) = doc(

--- a/t/builtin.pl
+++ b/t/builtin.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use App::perlimports::Document ();
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 my $doc
     = App::perlimports::Document->new( filename => 'test-data/builtin.pl' );

--- a/t/carp.t
+++ b/t/carp.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is_deeply', 'subtest' ];
+use Test::More import => [qw( done_testing is_deeply subtest )];
 
 subtest 'verbose' => sub {
     my ($doc) = doc( filename => 'test-data/carp.pl' );

--- a/t/cast-in-regex.t
+++ b/t/cast-in-regex.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is_deeply' ];
+use Test::More import => [qw( done_testing is_deeply )];
 use Test::Needs qw( Lingua::EN::Inflect );
 
 my ($doc) = doc(

--- a/t/cast.t
+++ b/t/cast.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( Mojo::Util );
 
 my ($doc) = doc(

--- a/t/cli.t
+++ b/t/cli.t
@@ -8,7 +8,7 @@ use Capture::Tiny qw( capture );
 use Path::Tiny ();
 use TestHelper qw( logger );
 use Test::Differences qw( eq_or_diff );
-use Test::More import => [ 'diag', 'done_testing', 'is', 'ok', 'subtest' ];
+use Test::More import => [qw( diag done_testing is ok subtest )];
 use Test::Needs qw( Perl::Critic::Utils );
 
 subtest '--filename' => sub {

--- a/t/config-in-import.pl
+++ b/t/config-in-import.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use App::perlimports::Document ();
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 my $doc = App::perlimports::Document->new(
     filename => 'test-data/config-in-import.pl' );

--- a/t/cpan-modules/pithub.t
+++ b/t/cpan-modules/pithub.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 'test-data/lib', 't/lib';
 
 use TestHelper qw( source2pi );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( Pithub );
 
 my $pi = source2pi(

--- a/t/cpan-modules/test2-v0.t
+++ b/t/cpan-modules/test2-v0.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use App::perlimports::ExportInspector ();
 use TestHelper qw( logger );
-use Test::More import => [ 'done_testing', 'ok' ];
+use Test::More import => [qw( done_testing ok )];
 use Test::Needs qw( Test2::V0 );
 
 my $ei = App::perlimports::ExportInspector->new(

--- a/t/datetime.t
+++ b/t/datetime.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( DateTime );
 
 my ( $doc, $logs ) = doc( filename => 'test-data/datetime.pl' );

--- a/t/do-block.t
+++ b/t/do-block.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( source2pi );
-use Test::More import => [ 'done_testing', 'is', 'ok' ];
+use Test::More import => [qw( done_testing is ok )];
 
 my $source_text
     = q{use Test::More do { $ENV{COVERAGE} ? ( skip_all => 'skip under Devel::Cover' ) : () };};

--- a/t/dump-perl-exports.t
+++ b/t/dump-perl-exports.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More import => [ 'done_testing', 'subtest' ];
+use Test::More import => [qw( done_testing subtest )];
 use Test::Needs qw( Moose );
 use Test::Script 1.27 qw(
     script_compiles

--- a/t/dupes.t
+++ b/t/dupes.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is', 'subtest' ];
+use Test::More import => [qw( done_testing is subtest )];
 
 subtest 'preserve duplicates' => sub {
     my ($doc) = doc(

--- a/t/english.t
+++ b/t/english.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 my ($doc) = doc( filename => 'test-data/english.pl' );
 

--- a/t/explodes.t
+++ b/t/explodes.t
@@ -5,7 +5,7 @@ use lib 't/lib', 'test-data/lib';
 
 use PPI::Document ();
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is', 'ok' ];
+use Test::More import => [qw( done_testing is ok )];
 
 my ( $doc, $log ) = doc(
     filename        => 'test-data/explodes.pl',

--- a/t/export-tags.t
+++ b/t/export-tags.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use TestHelper qw( doc );
 use Test::Differences qw( eq_or_diff );
-use Test::More import => ['done_testing'];
+use Test::More import => [qw( done_testing )];
 use Test::Needs { 'HTTP::Status' => 6.28 };
 
 my ($doc) = doc( filename => 'test-data/export-tags.pl' );

--- a/t/exported-variables.t
+++ b/t/exported-variables.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 'test-data/lib', 't/lib';
 
 use TestHelper qw( doc inc );
-use Test::More import => [ 'done_testing', 'is', 'is_deeply', 'ok' ];
+use Test::More import => [qw( done_testing is is_deeply ok )];
 
 my ($doc) = doc(
     filename  => 'test-data/exported-variables.pl',

--- a/t/find-bin.t
+++ b/t/find-bin.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc source2pi );
-use Test::More import => [ 'done_testing', 'is', 'is_deeply', 'ok' ];
+use Test::More import => [qw( done_testing is is_deeply ok )];
 
 my $e = source2pi(
     'test-data/find-bin.pl',

--- a/t/fully-qualified.t
+++ b/t/fully-qualified.t
@@ -5,7 +5,7 @@ use lib 't/lib', 'test-data/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => [ 'diag', 'done_testing', 'ok' ];
+use Test::More import => [qw( diag done_testing ok )];
 use Test::Needs qw( HTTP::Tiny );
 
 my ( $doc, $log ) = doc(

--- a/t/func-in-use.t
+++ b/t/func-in-use.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc source2pi );
-use Test::More import => [ 'done_testing', 'is', 'subtest' ];
+use Test::More import => [qw( done_testing is subtest )];
 use Test::Needs;
 
 subtest 'catdir' => sub {

--- a/t/func-in-var.t
+++ b/t/func-in-var.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( Mojo::Util );
 
 my ($doc) = doc(

--- a/t/geo-ip.t
+++ b/t/geo-ip.t
@@ -8,7 +8,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( source2pi );
-use Test::More import => [ 'done_testing', 'is', 'is_deeply' ];
+use Test::More import => [qw( done_testing is is_deeply )];
 use Test::Needs qw( Geo::IP );
 
 my $e = source2pi(

--- a/t/hash-in-regex.t
+++ b/t/hash-in-regex.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is', '$TODO' ];
+use Test::More import => [qw( done_testing is $TODO )];
 
 my ($doc) = doc( filename => 'test-data/hash-in-regex.pl' );
 my $expected = <<'EOF';

--- a/t/hash-key.t
+++ b/t/hash-key.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( file2includes source2pi );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( HTTP::Status );
 
 my @includes = file2includes('test-data/http-status.pl');

--- a/t/heredoc.t
+++ b/t/heredoc.t
@@ -5,7 +5,7 @@ use warnings;
 
 use lib 't/lib';
 
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw(  Perl::Critic::Utils );
 use TestHelper qw( source2pi );
 

--- a/t/ignored-modules.t
+++ b/t/ignored-modules.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc source2pi );
-use Test::More import => [ 'done_testing', 'is', 'ok' ];
+use Test::More import => [qw( done_testing is ok )];
 use Test::Needs qw( Geo::IP );
 
 {

--- a/t/import-error.t
+++ b/t/import-error.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'ok' ];
+use Test::More import => [qw( done_testing ok )];
 
 my $source_text = 'use Local::Module::Does::Not::Exist::At::All;';
 

--- a/t/interpolation.t
+++ b/t/interpolation.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => ['done_testing'];
+use Test::More import => [qw( done_testing )];
 
 my ($doc) = doc( filename => 'test-data/interpolation.pl' );
 

--- a/t/is-ignored.t
+++ b/t/is-ignored.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is', 'ok' ];
+use Test::More import => [qw( done_testing is ok )];
 
 my ($doc) = doc(
     filename => 'test-data/lib/Local/UsesTypesStandard.pm',

--- a/t/lookalike-words.t
+++ b/t/lookalike-words.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is_deeply' ];
+use Test::More import => [qw( done_testing is_deeply )];
 
 my ($doc) = doc(
     filename => 'test-data/lookalike-words.pl', preserve_unused => 0,

--- a/t/meta.t
+++ b/t/meta.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( Test2::V0 );
 
 my ($doc) = doc(

--- a/t/method.t
+++ b/t/method.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( LWP::UserAgent );
 
 my ($doc) = doc(

--- a/t/module-with-inner-packages.t
+++ b/t/module-with-inner-packages.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is', '$TODO' ];
+use Test::More import => [qw( done_testing is $TODO )];
 
 my ($doc) = doc( filename => 'test-data/lib/Local/WithInnerPkg.pm' );
 my $expected = <<'EOF';

--- a/t/moo.t
+++ b/t/moo.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 'test-data/lib', 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is', 'subtest' ];
+use Test::More import => [qw( done_testing is subtest )];
 use Test::Needs qw( Import::Into );
 
 subtest 'Moo' => sub {

--- a/t/moose-types.t
+++ b/t/moose-types.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/lib', 'test-data/lib';
 
 use TestHelper qw( source2pi );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( MooseX::Types::Path::Class );
 
 my $e = source2pi(

--- a/t/moose.t
+++ b/t/moose.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 'test-data/lib', 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is', 'subtest' ];
+use Test::More import => [qw( done_testing is subtest )];
 use Test::Needs qw( Import::Into Moose );
 
 subtest 'Moose' => sub {

--- a/t/moosex-types-moose.t
+++ b/t/moosex-types-moose.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( MooseX::Types MooseX::Types::Moose );
 
 my ($doc) = doc(

--- a/t/nested-quotes.t
+++ b/t/nested-quotes.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is_deeply' ];
+use Test::More import => [qw( done_testing is_deeply )];
 
 my ($doc) = doc( filename => 'test-data/nested-quotes.pl' );
 

--- a/t/never-exports.t
+++ b/t/never-exports.t
@@ -6,8 +6,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( source2pi );
-use Test::More import =>
-    [ 'done_testing', 'is', 'is_deeply', 'ok', 'subtest' ];
+use Test::More import => [qw( done_testing is is_deeply ok subtest )];
 use Test::Needs qw( Cpanel::JSON::XS LWP::UserAgent );
 
 subtest 'with version' => sub {

--- a/t/original-imports.pl
+++ b/t/original-imports.pl
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More import => [ 'done_testing', 'is_deeply' ];
+use Test::More import => [qw( done_testing is_deeply )];
 
 use App::perlimports::Document ();
 my $doc = App::perlimports::Document->new(

--- a/t/padding.t
+++ b/t/padding.t
@@ -5,7 +5,7 @@ use warnings;
 
 use lib 't/lib';
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 my ($doc) = doc(
     filename => 'test-data/carp.pl',

--- a/t/perl-imports.t
+++ b/t/perl-imports.t
@@ -6,8 +6,7 @@ use warnings;
 use lib 't/lib', 'test-data/lib';
 
 use TestHelper qw( doc source2pi );
-use Test::More import =>
-    [ 'done_testing', 'is', 'is_deeply', 'ok', 'subtest' ];
+use Test::More import => [qw( done_testing is is_deeply ok subtest )];
 
 subtest 'Getopt::Long' => sub {
     my $e = source2pi(

--- a/t/perl.t
+++ b/t/perl.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 my ($doc) = doc( filename => 'test-data/perl-version.pl' );
 my $expected = <<'EOF';

--- a/t/perlimports.t
+++ b/t/perlimports.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More import => [ 'done_testing', 'subtest' ];
+use Test::More import => [qw( done_testing subtest )];
 use Test::Needs qw( Moose );
 use Test::Script 1.27 qw(
     script_compiles

--- a/t/pragma.t
+++ b/t/pragma.t
@@ -10,7 +10,7 @@ use lib 't/lib';
 
 use Path::Tiny qw( path );
 use TestHelper qw( source2pi );
-use Test::More import => [ 'done_testing', 'is', 'ok' ];
+use Test::More import => [qw( done_testing is ok )];
 
 my $filename = 'test-data/pragma.t';
 

--- a/t/preserve-some-padding.t
+++ b/t/preserve-some-padding.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => ['done_testing'];
+use Test::More import => [qw( done_testing )];
 
 my ( $doc, $log ) = doc(
     filename        => 'test-data/preserve-some-padding.pl',

--- a/t/preserve-spaces.t
+++ b/t/preserve-spaces.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'subtest' ];
+use Test::More import => [qw( done_testing subtest )];
 use Test::Needs qw( HTTP::Status );
 
 subtest 'tidy_whitespace' => sub {

--- a/t/qualified-bareword.t
+++ b/t/qualified-bareword.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is_deeply' ];
+use Test::More import => [qw( done_testing is_deeply )];
 
 my ($doc) = doc(
     filename => 'test-data/qualified-bareword.pl', preserve_unused => 0,

--- a/t/quoted-var.t
+++ b/t/quoted-var.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 
 use Path::Tiny qw( path );
 use TestHelper qw( source2pi );
-use Test::More import => [ 'done_testing', 'is', 'ok' ];
+use Test::More import => [qw( done_testing is ok )];
 
 my $filename = 'test-data/quoted-var.pl';
 my $content  = path($filename)->slurp;

--- a/t/re-export-via-sub-exporter.t
+++ b/t/re-export-via-sub-exporter.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => ['done_testing'];
+use Test::More import => [qw( done_testing )];
 
 my ($doc) = doc(
     filename        => 'test-data/lib/Local/ReExportViaSubExporter.pm',

--- a/t/regex-replacement.t
+++ b/t/regex-replacement.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs { 'IP::Random' => '1.200230' };
 
 my ($doc) = doc(

--- a/t/require.t
+++ b/t/require.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 
 use Path::Tiny qw( path );
 use TestHelper qw( doc source2pi );
-use Test::More import => [ 'done_testing', 'is', 'ok', 'subtest' ];
+use Test::More import => [qw( done_testing is ok subtest )];
 use Test::Needs qw( LWP::UserAgent );
 
 my $filename = 'test-data/require.pl';

--- a/t/respace-include.pl
+++ b/t/respace-include.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use App::perlimports::Include ();
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 {
     my $AA = 'use Foo     qw( bar );';

--- a/t/script-with-inner-packages.t
+++ b/t/script-with-inner-packages.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( HTTP::Status );
 
 my ($doc) = doc(

--- a/t/signatures.pl
+++ b/t/signatures.pl
@@ -5,7 +5,7 @@ use Test::Needs { perl => 5.020 };
 
 use lib 't/lib';
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 my $expected = <<'EOF';
 use strict;

--- a/t/skip-all.t
+++ b/t/skip-all.t
@@ -6,7 +6,7 @@ use warnings;
 use lib 't/lib';
 use TestHelper qw( source2pi );
 use Test::Differences qw( eq_or_diff );
-use Test::More import => [qw( done_testing ok )],;
+use Test::More import => [qw( done_testing ok )];
 
 my $e = source2pi(
     'test-data/skip-all.t',

--- a/t/skip-all.t
+++ b/t/skip-all.t
@@ -5,7 +5,8 @@ use warnings;
 
 use lib 't/lib';
 use TestHelper qw( source2pi );
-use Test::More import => [ 'done_testing', 'is', 'ok' ];
+use Test::Differences qw( eq_or_diff );
+use Test::More import => [qw( done_testing ok )],;
 
 my $e = source2pi(
     'test-data/skip-all.t',
@@ -14,18 +15,16 @@ my $e = source2pi(
 
 ok( !$e->_is_ignored, 'not an ignored module' );
 my $expected = <<'EOF';
-use Test::More 0.93 (
-    foo      => ['bar'],
-    import   => [ 'is', 'is_deeply', 'ok' ],
-    skip_all => 'Test is broken',
-    tests    => 3
-);
+use Test::More 0.93 import => [qw( is is_deeply ok )],
+  foo                      => ['bar'],
+  skip_all                 => 'Test is broken',
+  tests                    => 3;
 EOF
 
 chomp $expected;
 
-is(
-    $e->formatted_ppi_statement,
+eq_or_diff(
+    $e->formatted_ppi_statement . q{},
     $expected,
     'formatted_ppi_statement'
 );

--- a/t/socket.t
+++ b/t/socket.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 my ($doc) = doc(
     filename => 'test-data/socket.pl',

--- a/t/sort-imports.t
+++ b/t/sort-imports.t
@@ -5,7 +5,7 @@ use lib 't/lib', 'test-data/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => ['done_testing'];
+use Test::More import => [qw( done_testing )];
 
 my ( $doc, $log ) = doc( filename => 'test-data/sort.pl' );
 

--- a/t/switches-in-import.t
+++ b/t/switches-in-import.t
@@ -3,7 +3,7 @@ use warnings;
 
 use App::perlimports::CLI ();
 use Capture::Tiny qw( capture );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 my $expected = <<'EOF';
 use strict;

--- a/t/symbol-as-method-call.t
+++ b/t/symbol-as-method-call.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use App::perlimports::Document ();
 use TestHelper qw( logger );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( HTML::TableExtract Object::Tap );
 
 my @errors;

--- a/t/symbol-in-export.t
+++ b/t/symbol-in-export.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 'test-data/lib', 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( HTTP::Status );
 
 my ( $doc, $log ) = doc(

--- a/t/test-builder.t
+++ b/t/test-builder.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use TestHelper qw( inspector );
 use Test::Needs qw( Test::HTML::Lint );
-use Test::More import => [ 'done_testing', 'ok' ];
+use Test::More import => [qw( done_testing ok )];
 
 my ($ei) = inspector('Test::HTML::Lint');
 

--- a/t/test-most.t
+++ b/t/test-most.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use App::perlimports::Document ();
 use TestHelper qw( logger );
-use Test::More import => [ 'done_testing', 'is', 'subtest' ];
+use Test::More import => [qw( done_testing is subtest )];
 use Test::Needs qw( Test::Most );
 
 my %modules = (

--- a/t/typeglob.t
+++ b/t/typeglob.t
@@ -4,7 +4,7 @@ use warnings;
 use lib 't/lib';
 
 use TestHelper qw( doc );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use Test::Needs qw( File::chdir );
 
 my ($doc) = doc(

--- a/t/use-and-require.t
+++ b/t/use-and-require.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use App::perlimports::Document ();
 use TestHelper qw( logger );
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 
 my @log;
 

--- a/t/var-in-hash-key.pl
+++ b/t/var-in-hash-key.pl
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use TestHelper qw( source2pi );
 
 my $source_text = 'use Perl::Critic::Utils;';

--- a/t/var-in-regex.t
+++ b/t/var-in-regex.t
@@ -3,7 +3,7 @@ use warnings;
 
 use lib 't/lib';
 
-use Test::More import => [ 'done_testing', 'is' ];
+use Test::More import => [qw( done_testing is )];
 use TestHelper qw( source2pi );
 use Test::Needs qw( Perl::Critic::Utils );
 

--- a/t/variable.t
+++ b/t/variable.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 use lib 't/lib';
-use Test::More import => [ 'done_testing', 'is', 'is_deeply' ];
+use Test::More import => [qw( done_testing is is_deeply )];
 use TestHelper qw( source2pi );
 
 my $source_text = 'use Getopt::Long qw( $REQUIRE_ORDER $RETURN_IN_ORDER );';

--- a/t/with-version.t
+++ b/t/with-version.t
@@ -5,7 +5,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper qw( doc );
-use Test::More import => [ 'diag', 'done_testing' ];
+use Test::More import => [qw( diag done_testing )];
 use Test::Needs {
     'Cpanel::JSON::XS' => 4.19,
     'Getopt::Long'     => 2.40,


### PR DESCRIPTION
Previously we'd turn:

use Test::More tests => 2;

into

use Test::More ( import => [ 'done_testing', 'pass' ], tests => 2 );

Now it should look like:

use Test::More import => [qw( done_testing pass )], tests => 2;

Closes #10
