### PR TITLE
Avoid exceptions when trying to unnest quotes

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -93,3 +93,8 @@ add_packages = Test::Builder
 
 # "use v5.14" is more readable than "use 5.014"
 [-ValuesAndExpressions::ProhibitVersionStrings]
+
+[-Subroutines::ProhibitExplicitReturnUndef]
+
+# Allow App::perlimports
+[-NamingConventions::Capitalization]

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for App-perlimports
 
 {{$NEXT}}
     - Update forked PPI to include PPI 1.272 (GH#64) (Olaf Alders)
+    - Avoid exceptions when trying to unnest quotes (GH#65) (Olaf Alders)
 
 0.000032  2022-01-15 03:41:49Z
     - Require Perl::Tidy version 20211029

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -570,7 +570,9 @@ sub _unnest_quotes {
 
     push @words, $self->_extract_symbols_from_snippet( $token->string );
 
-    my $doc    = PPI::Document->new( \$token->string );
+    my $doc = PPI::Document->new( \$token->string );
+    return @words unless $doc;
+
     my $quotes = $doc->find('PPI::Token::Quote');
     return @words unless $quotes;
 

--- a/t/unnest-quotes.t
+++ b/t/unnest-quotes.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use List::Util qw( none );
+use TestHelper qw( doc );
+use Test::More import => [qw( done_testing ok )];
+
+my @errors;
+
+my ( $doc, $logs ) = doc(
+    filename => 'test-data/unnest-quotes.pl',
+);
+$doc->tidied_document;
+
+ok(
+    do {
+        none { $_->{level} eq 'error' } @$logs;
+    },
+    'no errors in logs'
+);
+
+done_testing;

--- a/test-data/unnest-quotes.pl
+++ b/test-data/unnest-quotes.pl
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+
+use Carp qw( croak );
+
+my $green = "█";
+
+croak();


### PR DESCRIPTION
- Move perlcriticrc to .perlcriticrc
- Avoid exceptions when trying to unnest quotes
