### PR TITLE
Don't try to rewrite an import that we can't eval

### DIFF
--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -341,9 +341,14 @@ sub _build_includes {
                 && ( $_[1]->type eq 'use'
                 || $_[1]->type eq 'require' )
                 && !$self->_is_ignored( $_[1] )
-                && !$self->_has_import_switches( $_[1]->module );
+                && !$self->_has_import_switches( $_[1]->module )
+                && !App::perlimports::Sandbox::eval_pkg(
+                $_[1]->module,
+                "$_[1]"
+                );
         }
     ) || [];
+
 }
 
 sub _build_possible_imports {

--- a/lib/App/perlimports/Sandbox.pm
+++ b/lib/App/perlimports/Sandbox.pm
@@ -35,8 +35,9 @@ $content;
 1;
 EOF
 
+    ## no critic (Variables::RequireInitializationForLocalVars)
     local $@;
-    ## no critic (BuiltinFunctions::ProhibitStringyEval)
+    ## no critic (BuiltinFunctions::ProhibitStringyEval,ErrorHandling::RequireCheckingReturnValueOfEval)
     eval $to_eval;
 
     my $e = $@;

--- a/t/missing-semicolon-in-import.t
+++ b/t/missing-semicolon-in-import.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use Test::Differences qw( eq_or_diff );
+use TestHelper qw( doc );
+use Test::More import => [qw( diag done_testing )];
+
+my ( $doc, $log )
+    = doc( filename => 'test-data/missing-semicolon-in-import.pl' );
+
+my $expected = <<'EOF';
+use strict;
+use warnings;
+
+use Carp use POSIX;
+EOF
+
+eq_or_diff(
+    $doc->tidied_document,
+    $expected,
+    'broken imports are untouched'
+) || do { require Data::Dumper; diag Data::Dumper::Dumper($log); };
+
+done_testing();

--- a/test-data/lib/Local/Sort.pm
+++ b/test-data/lib/Local/Sort.pm
@@ -11,12 +11,13 @@ our @BBB     = ();
 our %CCC     = ();
 
 sub bbb     { }
-sub bbb_2fa { }
+sub bba_2fa { }
 
 our @EXPORT_OK = (
     '$AAA',
     '$AAA_2FA',
     'bbb',
+    'bba_2fa',
     '@BBB',
     '%CCC',
 );

--- a/test-data/missing-semicolon-in-import.pl
+++ b/test-data/missing-semicolon-in-import.pl
@@ -1,0 +1,4 @@
+use strict;
+use warnings;
+
+use Carp use POSIX;


### PR DESCRIPTION
PPI can misparse something like "use A use B;" as a "use A" with
arguments of "use" and "B".  If we trust PPI on this we will end up
tossing out "use B" when we process the includes. To avoid this we will
eval the include first. If an error is returned on the eval, we will
exclude this include. It can't be rewritten. It's possible something
wonky could happen because we haven't found two includes. We could also
just stop processing the file entirely in that case, but let's see how
far this gets us first.
