### PR TITLE
Flush memoize cache on object creation

### DIFF
--- a/lib/App/perlimports/ExportInspector.pm
+++ b/lib/App/perlimports/ExportInspector.pm
@@ -306,7 +306,7 @@ sub _list_to_hash {
     }
 
     # Specifically for File::chdir, which exports a typeglob, but doesn't
-    # implement eery possibility.
+    # implement every possibility.
     for my $key ( keys %hash ) {
         if ( substr( $key, 0, 1 ) eq '*' ) {
             my $thing = substr( $key, 1 );

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -6,7 +6,7 @@ our $VERSION = '0.000045';
 
 use Data::Dumper qw( Dumper );
 use List::Util   qw( any none uniq );
-use Memoize      qw( memoize );
+use Memoize      qw( flush_cache memoize );
 use MooX::StrictConstructor;
 use PPI::Document               ();
 use PPIx::Utils::Classification qw( is_function_call is_perl_builtin );
@@ -18,6 +18,10 @@ use Types::Standard qw(ArrayRef Bool HashRef InstanceOf Maybe Object Str);
 with 'App::perlimports::Role::Logger';
 
 memoize('is_function_call');
+
+sub BUILD {
+    flush_cache('is_function_call');
+}
 
 has _explicit_exports => (
     is          => 'ro',

--- a/t/memoize.t
+++ b/t/memoize.t
@@ -1,0 +1,39 @@
+#!perl
+
+use strict;
+use warnings;
+
+# This is a regression test for an error which occurrs when using
+# "memoize('is_function_call')" in Include.pm. It appears only in cases where
+# the CLI is processing multiple files in a specific order. In the bug
+# scenario, "use MooseX::Types::UUID ();" in test-data/b.pl is transformed to
+# "use MooseX::Types::UUID qw( UUID );", despite the fact that "UUID" is not an
+# imported symbol in b.pl. This happens in the case where "a.pl" is process
+# first and "is_function_call('UUID')" has already been memoized.
+#
+# We use "memoize" on "is_function_call" because it was identified as a hotspot
+# in earlier profiling.
+
+use lib 't/lib';
+
+use Path::Tiny        qw( path );
+use Test::Differences qw( eq_or_diff );
+use TestHelper        qw( doc );
+use Test::More import => [qw( done_testing )];
+use Test::Needs qw( MooseX::Types::UUID UUID );
+
+{
+    my ($doc) = doc( filename => 'test-data/a.pl' );
+    $doc->tidied_document;
+}
+
+{
+    my ($doc) = doc( filename => 'test-data/b.pl', preserve_unused => 1, );
+    eq_or_diff(
+        $doc->tidied_document,
+        path('test-data/b.pl')->slurp,
+        'doc has not changed'
+    );
+}
+
+done_testing();

--- a/test-data/a.pl
+++ b/test-data/a.pl
@@ -1,0 +1,10 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use MooseX::Types::UUID qw(UUID);
+
+foo(UUID);
+
+sub foo {}

--- a/test-data/b.pl
+++ b/test-data/b.pl
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use MooseX::Types::UUID ();
+use UUID qw( uuid );
+
+foo(uuid);
+
+sub foo {}

--- a/test-needs-cpanfile
+++ b/test-needs-cpanfile
@@ -20,10 +20,12 @@ on 'test' => sub {
     requires 'MooseX::Types' => 0;
     requires 'MooseX::Types::Moose' => 0;
     requires 'MooseX::Types::Path::Class' => 0;
+    requires 'MooseX::Types::UUID' => 0;
     requires 'Object::Tap' => 0;
     requires 'Perl::Critic::Utils' => 0;
     requires 'Pithub' => '0';
     requires 'Test2::V0' => '0';
     requires 'Test::HTML::Lint' => '0';
     requires 'Test::Most' => '0';
+    requires 'UUID' => '0';
 };


### PR DESCRIPTION
- Apply perltidy 20220613
- Flush memoize cache every time a new Include.pm object is created
