### PR TITLE
Bump PPI from 1.274 to 1.276

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -32,7 +32,7 @@ File::XDG = 1.01
 Log::Dispatch = 2.70
 perl = 5.18.0
 Perl::Tidy = 20220613
-PPI = 1.274
+PPI = 1.276
 Symbol::Get = 0.10
 TOML::Tiny = 0
 


### PR DESCRIPTION
This is the version of PPI where the replace method is implemented.
