### PR TITLE
Bump TOML::Tiny version from 0 to 0.16

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -35,7 +35,7 @@ perl = 5.18.0
 Perl::Tidy = 20220613
 PPI = 1.276
 Symbol::Get = 0.10
-TOML::Tiny = 0
+TOML::Tiny = 0.16
 
 ; Mostly needed for files in ./test-data
 [Prereqs / TestRequires]


### PR DESCRIPTION
This essentially reverts 045db2e32cdedb which came in via #78 We could
probably find some fancy way to work around this, but the basic problem
is that we don't want reports from CPAN testers running 5.38 that
include warnings about the use of "when" in older versions of TOML::Tiny
