### PR TITLE
Lint unknowns

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,15 @@
 Revision history for App-perlimports
 
 {{$NEXT}}
+    - New: option --lint-unknowns will warn you about unknown functions
+      (GH#137) (pyrrhlin)
+    - recognize and parse constant definitions (GH#141) (pyrrhlin)
+    - Rename poorly named attribute "original_imports" (GH#140) (pyrrhlin)
+    - Fix: minor bug that could cause an imported symbol to appear twice
+      (GH#139) (pyrrhlin)
+    - several performance enhancements (GH#138, GH#143) (pyrrhlin)
+    - tests for bad handling of duplicate imports (GH#145) (pyrrhlin)
+    - build test tweaks (differentiate perlcritic policies for tests)
 
 0.000058  2025-10-28 17:06:33Z
     - Fix: Recognize function references (\&Module::func) as valid module usage

--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -182,7 +182,7 @@ sub _build_args {
         [],
         [
             'lint-unknowns',
-            'When linting, report unknown functions.',
+            'Act as a linter, and report unknown functions.',
         ],
         [],
         [
@@ -412,7 +412,9 @@ sub run {
         return 1;
     }
 
-    if ( $self->_lint && $self->_inplace_edit ) {
+    my $lintmode = $self->_lint || $self->_opts->lint_unknowns;
+
+    if ( $lintmode && $self->_inplace_edit ) {
         $logger->error('Cannot lint if inplace edit has been enabled');
         return 1;
     }
@@ -452,7 +454,7 @@ sub run {
         ? ( never_export_modules => $self->_config->never_export )
         : (),
         json                => $self->_json,
-        lint                => $self->_lint,
+        lint                => $lintmode,
         lint_unknowns       => $self->_opts->lint_unknowns,
         logger              => $logger,
         padding             => $self->_config->padding,
@@ -482,7 +484,7 @@ FILENAME:
         # piped back into vim.
         my ( $stdout, $tidied, $linter_success );
 
-        if ( $self->_lint ) {
+        if ($lintmode) {
             ( $stdout, $linter_success ) = capture_stdout(
                 sub {
                     return $pi_doc->linter_success;

--- a/lib/App/perlimports/CLI.pm
+++ b/lib/App/perlimports/CLI.pm
@@ -181,6 +181,11 @@ sub _build_args {
         ],
         [],
         [
+            'lint-unknowns',
+            'When linting, report unknown functions.',
+        ],
+        [],
+        [
             'no-config-file',
             'Do not look for a perlimports config file.'
         ],
@@ -448,6 +453,7 @@ sub run {
         : (),
         json                => $self->_json,
         lint                => $self->_lint,
+        lint_unknowns       => $self->_opts->lint_unknowns,
         logger              => $logger,
         padding             => $self->_config->padding,
         preserve_duplicates => $self->_config->preserve_duplicates,

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -1140,7 +1140,6 @@ sub linter_success {
 # Kind of on odd interface, but right now we return either a tidied document or
 # the result of linting. Could probably clean this up at some point, but I'm
 # not sure yet how much the linting will change.
-# N.B. In lint mode, we never modify the document.
 sub _lint_or_tidy_document {
     my $self = shift;
 
@@ -1237,37 +1236,38 @@ INCLUDE:
         }
         ## use critic
 
-        my $inserted = $include->replace($elem);
-        if ( !$inserted ) {
+        # here we modify the PPI document, making the 'found_imports' and
+        # 'includes' attributes "stale".
+        # $include is untouched, other than now having no parent.
+        unless ( $include->replace($elem) ) {
             $self->logger->error( 'Could not insert ' . $elem );
+            next INCLUDE;
         }
-        else {
-            $processed{ $include->module } = 1;
 
-            if ( $self->lint ) {
-                my $before = join q{ },
-                    map { $_->content } $include->arguments;
-                my $after = join q{ }, map { $_->content } $elem->arguments;
+        $processed{ $include->module } = 1;
 
-                if ( $before ne $after ) {
-                    $self->_warn_diff_for_linter(
-                        'import arguments need tidying',
-                        $include,
-                        $include->content,
-                        $elem->content
-                    );
-                    $linter_error = 1;
-                }
-                next INCLUDE;
+        if ( $self->lint ) {
+            my $before = join q{ }, map { $_->content } $include->arguments;
+            my $after  = join q{ }, map { $_->content } $elem->arguments;
+
+            if ( $before ne $after ) {
+                $self->_warn_diff_for_linter(
+                    'import arguments need tidying',
+                    $include,
+                    $include->content,
+                    $elem->content,
+                );
+                $linter_error = 1;
             }
-
-            $self->logger->info("resetting imports for |$elem|");
-
-            $self->_reset_found_import(
-                $include->module,
-                _imports_for_include($elem)
-            );
+            next INCLUDE;
         }
+
+        $self->logger->info("resetting imports for |$elem|");
+
+        $self->_reset_found_import(
+            $include->module,
+            _imports_for_include($elem)
+        );
     }
 
     $self->_maybe_cache_inspectors;

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -1312,15 +1312,32 @@ INCLUDE:
 sub _elem_loc {
     my ($elem) = @_;
 
-    my $loc     = { start => { line => $elem->line_number } };
-    my $content = $elem->content;
-    my @lines   = split( m{\n}, $content );
+    my $loc = {
+        start => {
+            line   => $elem->line_number,
+            column => $elem->column_number,
+        }
+    };
 
-    if ( $lines[0] =~ m{[^\s]} ) {
-        $loc->{start}->{column} = @-;
+    # note: PPI::Statement::Null exists (content '')
+    my $content = $elem->content;
+
+    # handle PPI::Token::HereDoc with content of e.g. '<<TERM'
+    # heredoc lines end with newline, content and terminator do not
+    if ( ref $elem eq 'PPI::Token::HereDoc' ) {
+        $content .= join '', "\n", $elem->heredoc, $elem->terminator;
     }
-    $loc->{end}->{line}   = $elem->line_number + @lines - 1;
-    $loc->{end}->{column} = length( $lines[-1] );
+
+    my @lines  = split( m{\n}, $content );
+    my $length = length( @lines ? $lines[-1] : $content );
+
+    $loc->{end}{line} = $elem->line_number + @lines - 1;
+    if ( @lines == 1 ) {
+        $loc->{end}{column} = $elem->column_number - 1 + $length;
+    }
+    else {
+        $loc->{end}{column} = $length;
+    }
 
     return $loc;
 }

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -475,7 +475,7 @@ sub _parse_hashlist {
 
     # first and last commas are ignored, if no significant child exists beyond!
     # interior serial commas are not handled properly: {a => 1, 'b', , 'c', 4}
-    return my @values = split_nodes_on_comma(@tokens);
+    return split_nodes_on_comma(@tokens);
 }
 
 # until we get a PPI::Statement::Include::Constant class

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -87,7 +87,8 @@ has includes => (
     isa         => ArrayRef [Object],    # PPI::Statement::Include
     handles_via => 'Array',
     handles     => {
-        all_includes => 'elements',
+        all_includes     => 'elements',
+        refresh_includes => 'reset',
     },
     lazy    => 1,
     builder => '_build_includes',
@@ -1146,7 +1147,8 @@ sub _lint_or_tidy_document {
     my $self = shift;
 
     my $linter_error = 0;
-    my %processed;    # modules we changed/confirmed the use statement
+    my %processed;         # modules we changed/confirmed the use statement
+    my $includes_stale;    # whether we edited any include statements
 
 INCLUDE:
     foreach my $include ( $self->all_includes ) {
@@ -1246,13 +1248,13 @@ INCLUDE:
             next INCLUDE;
         }
 
+        $includes_stale = 1;
         $processed{ $include->module } = 1;
 
         $self->logger->info("resetting imports as |$elem|");
 
-        # update found_imports attribute to reflect the changes we made.
-        # this ensures lint_unknowns doesn't report the newly-identified
-        # imports as unknown.
+        # updating 'found_imports' ensures lint_unknowns doesn't report the
+        # newly-identified imports as unknown.
         $self->_reset_found_import(
             $include->module,
             _imports_for_include($elem)
@@ -1273,6 +1275,9 @@ INCLUDE:
             }
         }
     }
+
+    # refresh stale attribute, just for consistency.
+    $self->refresh_includes if $includes_stale;
 
     $self->_maybe_cache_inspectors;
 

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -229,6 +229,7 @@ has ppi_document => (
 
 # list of tokens in the document that -could- have come from an import
 # (but most are keywords, built-ins, lexical vars, defined funcs, etc.)
+# excludes constants, package names.
 has possible_imports => (
     is          => 'ro',
     isa         => ArrayRef [Object],    # isa PPI:Token:Word, :Symbol, :Magic
@@ -458,7 +459,8 @@ sub _build_constants {
         }
     }
 
-    $self->logger->debug("constants found: @{[sort keys %constant]}");
+    $self->logger->debug("constants found: @{[sort keys %constant]}")
+        if %constant;
 
     return \%constant;
 }
@@ -610,6 +612,8 @@ sub _build_possible_imports {
         next
             if $const{"$word"}
             && ( is_hash_key($word) || is_function_call($word) );
+
+        # NOTE: not yet tracking package scope (if file_scoped false)!
         next if $pack{"$word"} && is_class_name($word);   # class method calls
 
         push @after, $word;
@@ -1303,6 +1307,8 @@ INCLUDE:
 
 # given PPI:Element, returns hashref describing location, e.g.:
 #   {start => {line => 3, column => 4}, end => {...}}
+# NOTE: the "column" name is misleading: it is actually character number
+# (which is not the same if tabs or double-width chars are present)
 sub _elem_loc {
     my ($elem) = @_;
 

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -1143,6 +1143,7 @@ sub linter_success {
 # Kind of on odd interface, but right now we return either a tidied document or
 # the result of linting. Could probably clean this up at some point, but I'm
 # not sure yet how much the linting will change.
+## no critic (Subroutines::ProhibitExcessComplexity)
 sub _lint_or_tidy_document {
     my $self = shift;
 
@@ -1294,6 +1295,7 @@ INCLUDE:
     # See https://metacpan.org/pod/PPI::Document#serialize
     return $self->lint ? !$linter_error : $self->_ppi_selection->serialize;
 }
+## use critic
 
 # given PPI:Element, returns hashref describing location, e.g.:
 #   {start => {line => 3, column => 4}, end => {...}}

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -1264,6 +1264,15 @@ INCLUDE:
 
     $self->_maybe_cache_inspectors;
 
+    if ( $self->lint ) {
+        my @unknown = @{ $self->unknown_words };    # PPI:Token:Word
+        if (@unknown) {
+            $linter_error = 1;    # if $self->_some_feature_enabled;
+            $self->_warn_line_for_linter( 'Unknown function', $_ )
+                for @unknown;
+        }
+    }
+
     # We need to do serialize in order to preserve HEREDOCs.
     # See https://metacpan.org/pod/PPI::Document#serialize
     return $self->lint ? !$linter_error : $self->_ppi_selection->serialize;
@@ -1285,6 +1294,51 @@ sub _elem_loc {
     $loc->{end}->{column} = length( $lines[-1] );
 
     return $loc;
+}
+
+sub _line_count {
+    my ($self) = @_;
+    my $doc    = $self->ppi_document;
+    my $number = $doc->last_token && $doc->last_token->line_number;
+    return my $line_count = $number || 1 + $doc->content =~ tr/\n//;
+}
+
+sub _warn_line_for_linter {
+    my ( $self, $reason, $elem ) = @_;
+
+    my $name
+        = $elem->isa('PPI::Token::Quote') ? $elem->string
+        : $elem->isa('PPI::Token::Word')  ? $elem->content
+        :                                   q{};
+    my $stm = $elem->statement;
+
+    if ( $self->json ) {
+
+        my $json = {
+            filename => $self->_filename,
+            location => _elem_loc($elem),
+            reason   => $reason,
+            ( name      => $name ) x !!$name,
+            ( statement => $stm->content ) x !!$stm,
+        };
+        $self->logger->error( $self->_json_encoder->encode($json) );
+    }
+    else {
+
+        my $justification = sprintf(
+            '❌ %s (%s) at %s line %i',
+            $reason, $name, $self->_filename, $elem->line_number
+        );
+        $self->logger->error($justification);
+        if ($stm) {
+            my $wid  = length( $self->_line_count );
+            my $line = sprintf(
+                " %${wid}u %s\n", $stm->line_number,
+                $stm->content
+            );
+            $self->logger->error($line);
+        }
+    }
 }
 
 sub _warn_diff_for_linter {

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -185,6 +185,7 @@ has found_imports => (
     handles_via => 'Hash',
     handles     => {
         _reset_found_import => 'set',
+        found_imports_from  => 'get',
     },
     lazy    => 1,
     builder => '_build_found_imports',
@@ -947,9 +948,8 @@ sub _has_import_switches {
     # We will leave this case as broken for the time being. I'm not sure how
     # common that invocation is.
 
-    if ( exists $self->found_imports->{$module_name}
-        && any { $_ =~ m{^[\-]} }
-        @{ $self->found_imports->{$module_name} || [] } ) {
+    my $imports = $self->found_imports_from($module_name);
+    if ( $imports && any { $_ =~ m{^[\-]} } @$imports ) {
         return 1;
     }
     return 0;

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -314,6 +314,10 @@ around BUILDARGS => sub {
         $args{ppi_selection} = PPI::Document->new( \$selection );
     }
 
+    if ( !exists $args{lint} ) {
+        $args{lint} = 1 if $args{lint_unknowns};
+    }
+
     return $class->$orig(%args);
 };
 

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -198,7 +198,7 @@ has _never_export_modules => (
 
 # catalog of symbols explicitly imported (by package), e.g.
 #  Carp => ['croak', ..], ...
-# in edit mode, this will be altered after processing (tidied_document)
+# will be altered while processing (linter_success or tidied_document)
 # to reflect what we think the import statement should be.
 has found_imports => (
     is          => 'ro',
@@ -672,10 +672,12 @@ sub _build_ppi_document {
 #     POSIX => [],
 # }
 #
-# In lint mode, it never changes.  In edit mode, it starts out as a list of
-# original imports, but with each include that gets processed, this list gets
-# updated. We do this so that we can keep track of what previous modules
-# are really importing, avoiding duplicate imports.
+# This attribute starts out as just what the source document says. Then,
+# when processing (lint or tidy) each include, if we change the imports in
+# the statement, then this list also gets updated.  We do this to keep track
+# of what previous modules are really importing, both to detect duplicate
+# imports (same symbol from different packages), and so that these
+# found symbols can be excluded from the list of unknown words.
 
 sub _build_found_imports {
     my $self = shift;
@@ -1246,6 +1248,16 @@ INCLUDE:
 
         $processed{ $include->module } = 1;
 
+        $self->logger->info("resetting imports as |$elem|");
+
+        # update found_imports attribute to reflect the changes we made.
+        # this ensures lint_unknowns doesn't report the newly-identified
+        # imports as unknown.
+        $self->_reset_found_import(
+            $include->module,
+            _imports_for_include($elem)
+        );
+
         if ( $self->lint ) {
             my $before = join q{ }, map { $_->content } $include->arguments;
             my $after  = join q{ }, map { $_->content } $elem->arguments;
@@ -1259,15 +1271,7 @@ INCLUDE:
                 );
                 $linter_error = 1;
             }
-            next INCLUDE;
         }
-
-        $self->logger->info("resetting imports for |$elem|");
-
-        $self->_reset_found_import(
-            $include->module,
-            _imports_for_include($elem)
-        );
     }
 
     $self->_maybe_cache_inspectors;
@@ -1553,12 +1557,11 @@ e.g.
 
   { Carp => ['croak', ..], ... }
 
-In lint mode, this attribute is never altered.
-
-In edit mode, when L<tidied_document> is called, with each include that gets
-processed, this list gets updated to what we think it should be.  We do this
-so that we can keep track of what previous modules are really importing, to
-avoid duplicate imports (same symbol name from different packages).
+When processing (lint or tidy) each include, this list gets updated to what
+we think it should be.  We do this so that we can keep track of what previous
+modules are really importing, to detect duplicate imports (same symbol name
+from different packages), and so these found symbols can be excluded
+from the list of unknown words.
 
 =item unknown_words
 
@@ -1571,9 +1574,10 @@ both common mistakes, and very useful to detect in lint mode.
 
 Only the first occurrence of each word is saved.
 
-Note: Because generating this list depends on the L<found_imports>,
-one should use L<linter_success> first to find all possible imports that
-were omitted first.
+Note: Because generating this list depends on the L<found_imports>, if you
+build this attribute before processing the document (e.g. L<linter_success>),
+it will include words that were identified as missing imports.  If you
+process first, it will exclude those.
 
 Note 2: There will sometimes be false positives, since Perl is a highly dynamic
 language, and the static analysis here cannot handle black magic of runtime

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -167,6 +167,14 @@ has lint => (
     default => 0,
 );
 
+# (lint mode only) whether to report on unknown functions
+has lint_unknowns => (
+    is      => 'ro',
+    isa     => Bool,
+    lazy    => 1,
+    default => 0,
+);
+
 has my_own_inspector => (
     is      => 'ro',
     isa     => Maybe [ InstanceOf ['App::perlimports::ExportInspector'] ],
@@ -1264,10 +1272,10 @@ INCLUDE:
 
     $self->_maybe_cache_inspectors;
 
-    if ( $self->lint ) {
+    if ( $self->lint && $self->lint_unknowns ) {
         my @unknown = @{ $self->unknown_words };    # PPI:Token:Word
         if (@unknown) {
-            $linter_error = 1;    # if $self->_some_feature_enabled;
+            $linter_error = 1;
             $self->_warn_line_for_linter( 'Unknown function', $_ )
                 for @unknown;
         }

--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -21,6 +21,8 @@ use PPIx::Utils::Classification qw(
     is_hash_key
     is_method_call
     is_package_declaration
+    is_perl_builtin
+    is_qualified_name
 );
 use PPIx::Utils::Traversal qw( split_nodes_on_comma );
 use Ref::Util              qw( is_plain_arrayref is_plain_hashref );
@@ -104,6 +106,17 @@ has constants => (
     predicate => '_has_constants',
     lazy      => 1,
     builder   => '_build_constants',
+);
+
+has unknown_words => (
+    is          => 'ro',
+    isa         => ArrayRef [Object],    # PPI::Token::Word
+    handles_via => 'Array',
+    handles     => {
+        all_unknowns => 'elements',
+    },
+    lazy    => 1,
+    builder => '_build_unknowns',
 );
 
 has _inspectors => (
@@ -598,6 +611,40 @@ sub _build_possible_imports {
     return \@after;
 }
 ## use critic
+
+# array of PPI::Token::Word that are not known to be defined.
+# not every unknown word, just the first occurrence of each.
+sub _build_unknowns {
+    my $self = shift;
+    my %unknown;
+
+    my $imports = $self->found_imports;
+    my %imported_symbol;    # invert the found_imports hash
+    foreach my $pkg ( keys %$imports ) {
+        next unless my $foundlist = $self->found_imports_from($pkg);
+        $imported_symbol{$_} = $pkg for @$foundlist;
+    }
+
+    # method calls and known package name used in class-method call
+    # were already excluded.
+
+    # we're really looking only for undefined functions
+    foreach my $word ( $self->possibly_imported_tokens ) {    # PPI:Element
+        next unless $word->isa('PPI::Token::Word');
+
+        next if is_perl_builtin($word);
+        next unless is_function_call($word);
+
+        next
+            if $imported_symbol{"$word"}
+            || is_qualified_name($word)
+            || $self->is_constant_name("$word");
+
+        $unknown{"$word"} ||= $word;
+    }
+    my @sorted = sort { "$a" cmp "$b" } values %unknown;
+    return \@sorted;
+}
 
 sub _build_ppi_document {
     my $self = shift;
@@ -1450,6 +1497,25 @@ In edit mode, when L<tidied_document> is called, with each include that gets
 processed, this list gets updated to what we think it should be.  We do this
 so that we can keep track of what previous modules are really importing, to
 avoid duplicate imports (same symbol name from different packages).
+
+=item unknown_words
+
+An arrayref of L<PPI::Token::Word>'s (in alphabetic order) found in the
+document which do not seem to be defined anywhere.
+
+These would include functions that are not from any package mentioned in the
+document (so, a forgotten dependency), or misspelled (or typo) function names,
+both common mistakes, and very useful to detect in lint mode.
+
+Only the first occurrence of each word is saved.
+
+Note: Because generating this list depends on the L<found_imports>,
+one should use L<linter_success> first to find all possible imports that
+were omitted first.
+
+Note 2: There will sometimes be false positives, since Perl is a highly dynamic
+language, and the static analysis here cannot handle black magic of runtime
+code-generation.  Only useful 95% of the time!
 
 =back
 

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -700,7 +700,7 @@ sub _is_already_imported {
         my @imports;
         if ( is_plain_arrayref( $self->_document->found_imports->{$module} ) )
         {
-            @imports = @{ $self->_document->found_imports->{$module} };
+            @imports = @{ $self->_document->found_imports_from($module) };
             $self->logger->debug(
                 'Explicit imports found: ' . Dumper( [ sort @imports ] ) );
         }

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -630,9 +630,12 @@ sub _maybe_get_new_include {
 
     # Prefix newlines to reproduce original's location
     ## no critic (BuiltinFunctions::ProhibitLvalueSubstr)
-    my $doc = do {
-        my $line = $orig->line_number || 1;
+    ## no critic (ControlStructures::ProhibitNegativeExpressionsInUnlessAndUntilConditions)
+    return $orig unless my $doc = do {
+        my $line = $orig->line_number   || 1;
+        my $pos  = $orig->column_number || 1;
         my $text = "\n" x $line;
+        substr( $text, -1 ) = q{ } x $pos if $pos > 1;
         substr( $text, -1 ) = $statement;
         PPI::Document->new( \$text, filename => $orig->logical_filename );
     };
@@ -641,10 +644,10 @@ sub _maybe_get_new_include {
     # Cloning is necessary because the tokens in the found statement belong
     # to the document. When the document is destroyed, the tokens go with it.
     # With the clone, the duplicated tokens are independent of the doc.
-    my $rewrite = do {
+    return $orig unless my $rewrite = do {
         $doc->index_locations;
         my $includes = $doc->find('Statement::Include');
-        $includes->[0]->clone;
+        $includes && @$includes && $includes->[0]->clone;
     };
 
     # If the -only- difference is some whitespace before the symbol list, we

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -5,7 +5,8 @@ use Moo;
 our $VERSION = '0.000059';
 
 ## no critic (Bangs::ProhibitDebuggingModules)
-
+# Data::Dumper is used at runtime to serialize import argument hash lists for
+# Test::Builder-based modules (see _build_formatted_ppi_statement).
 use Data::Dumper qw( Dumper );
 use List::Util   qw( any none uniq );
 use Memoize      qw( flush_cache memoize );

--- a/perlcriticrc
+++ b/perlcriticrc
@@ -104,6 +104,9 @@ add_packages = Test::Builder
 
 # --- policies that should not be applied to tests:
 
+[Subroutines::ProtectPrivateSubs]
+add_themes = nontest
+
 [Bangs::ProhibitNumberedNames]
 add_themes = nontest
 

--- a/perlcriticrc
+++ b/perlcriticrc
@@ -26,7 +26,7 @@ severity = 3
 [Documentation::RequirePackageMatchesPodName]
 severity = 3
 
-[Freenode::WhileDiamondDefaultAssignment]
+[Community::WhileDiamondDefaultAssignment]
 set_themes = core
 
 [InputOutput::RequireCheckedSyscalls]

--- a/t/cli.t
+++ b/t/cli.t
@@ -212,6 +212,21 @@ EOF
 
     is( $stderr, $expected, 'STDERR' );
     is( $exit,   1,         'exit code is error' );
+
+    # same result using --lint-unknowns (which implies --lint)
+    local @ARGV = (
+        '--lint-unknowns',
+        '--no-config-file',
+        '-f' => 'test-data/lint-failure-import-args.pl',
+    );
+    $cli = App::perlimports::CLI->new;
+    ( $stdout, $stderr, $exit ) = capture {
+        $cli->run;
+    };
+    is( $stdout, q{}, 'no STDOUT with --lint-unknowns' );
+
+    is( $stderr, $expected, 'STDERR is the same' );
+    is( $exit,   1,         'exit code is same error' );
 };
 
 subtest '--lint failure unused import' => sub {
@@ -361,6 +376,16 @@ subtest '--lint with -i' => sub {
     like(
         $stderr, qr{Cannot lint if inplace edit has been enabled},
         'trying to edit and lint at once'
+    );
+
+    local @ARGV = ( '--lint-unknowns', '-i', 'test-data/var-in-hash-key.pl' );
+    $cli = App::perlimports::CLI->new;
+    ( undef, $stderr ) = capture {
+        $cli->run;
+    };
+    like(
+        $stderr, qr{Cannot lint if inplace edit has been enabled},
+        'exact same error with --lint-unknowns -i'
     );
 };
 

--- a/t/doc-imports.t
+++ b/t/doc-imports.t
@@ -6,7 +6,9 @@ use warnings;
 use lib 'test-data/lib', 't/lib';
 
 use App::perlimports::Document ();
+use PPI::Document              ();
 use TestHelper                 qw( logger );
+use Test::Differences          qw( eq_or_diff );
 use Test::More import => [qw( done_testing is is_deeply subtest )];
 
 subtest 'linting doesnt change found_imports' => sub {
@@ -31,8 +33,8 @@ subtest 'linting doesnt change found_imports' => sub {
         = grep { $_->{message} =~ /import arguments need tidying/ } @log;
     is $found, 2, 'log indicates Carp imports need fixing';
 
-    is_deeply $doc->found_imports, $original_imports,
-        'but doc found_imports unchanged in lint mode';
+    eq_or_diff $doc->found_imports, { Carp => ['croak'] },
+        'and doc found_imports changed in lint mode';
 };
 
 subtest 'found_imports edited' => sub {
@@ -54,7 +56,7 @@ subtest 'found_imports edited' => sub {
     my $clean_source = $doc->tidied_document;
 
     my $found
-        = grep { $_->{message} =~ /resetting imports for .use Carp/ } @log;
+        = grep { $_->{message} =~ /resetting imports as .use Carp/ } @log;
     is $found, 2, 'log indicates Carp import was fixed';
 
     is_deeply $doc->found_imports, $clean_imports,

--- a/t/elem-loc.t
+++ b/t/elem-loc.t
@@ -110,5 +110,30 @@ TODO: {
     }
 };
 
+subtest 'heredoc' => sub {
+    my ( $doc, $log ) = doc(
+        filename      => 'test-data/elem-loc.pl',
+        lint_unknowns => 1,
+        json          => 1,
+    );
+    my $ppidoc = $doc->ppi_document;
+
+    my $found = $ppidoc->find(
+        sub {
+            $_[1]->isa('PPI::Token::HereDoc');
+        }
+    ) || [];
+    my $heredoc = $found->[0];
+
+    is_deeply $heredoc->location,
+        [ 13, 11, 11, 13, 'test-data/elem-loc.pl' ],
+        ':Token:HereDoc location';
+    is_deeply App::perlimports::Document::_elem_loc($heredoc), {
+        start => { line => 13, column => 11 },
+        end   => { line => 15, column => 3 },
+        },
+        ':Token:HereDoc elem_loc';
+};
+
 done_testing();
 

--- a/t/elem-loc.t
+++ b/t/elem-loc.t
@@ -1,0 +1,114 @@
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use Cpanel::JSON::XS qw( decode_json );
+use TestHelper       qw( doc );
+use Test::More import => [qw( done_testing is is_deeply subtest $TODO )];
+use Test::Needs {
+    'Cpanel::JSON::XS' => 4.19,
+    'Getopt::Long'     => 2.40,
+    'LWP::UserAgent'   => 5.00,
+};
+use App::perlimports::Document ();
+
+subtest 'json linting gets correct locations' => sub {
+    my ( $doc, $log ) = doc(
+        filename      => 'test-data/elem-loc.pl',
+        lint_unknowns => 1,
+        json          => 1,
+    );
+
+    # prior to processing:
+    my $includes = $doc->includes;
+
+    my ($firstinclude) = $includes->[0];
+    is_deeply App::perlimports::Document::_elem_loc($firstinclude), {
+        start => { line => 5, column => 3 },
+        end   => { line => 5, column => 44 },
+        },
+        'first include stm elem_loc';
+
+    my ($longinclude) = grep { $_->content =~ /Test::Script/ } @$includes;
+    is_deeply $longinclude->location, [ 6, 1, 1, 6, 'test-data/elem-loc.pl' ],
+        'include stm location (before)';
+    is_deeply App::perlimports::Document::_elem_loc($longinclude), {
+        start => { line => 6, column => 1 },
+        end   => { line => 7, column => 41 },
+        },
+        'long include stm elem_loc';
+
+    my ($lastinclude) = $includes->[-1];
+    is_deeply App::perlimports::Document::_elem_loc($lastinclude), {
+        start => { line => 8, column => 1 },
+        end   => { line => 8, column => 27 },
+        },
+        'last include stm elem_loc';
+
+    is $doc->linter_success, q{}, 'linting failed';
+
+    my @errs = grep { $_->{level} eq 'error' } @$log;
+    $_->{message} = decode_json( $_->{message} ) for @errs;
+
+    # the first error message is about the Cpanel::JSON::XS include
+    my $found = shift @errs;
+    is $found->{message}{module}, 'Cpanel::JSON::XS',
+        'found the Cpanel::JSON::XS log';
+    is_deeply $found->{message}{location}, {
+        start => { line => 5, column => 3 },
+        end   => { line => 5, column => 44 },
+        },
+        'json log gets column of indented statement correct';
+
+    # the next error message is about the Test::Script include
+    $found = shift @errs;
+    is $found->{message}{module}, 'Test::Script', 'found the Test:Script log';
+    is_deeply $found->{message}{location}, {
+        start => { line => 6, column => 1 },
+        end   => { line => 7, column => 41 },
+        },
+        'json log gets location of multiline statement correct';
+
+    # the final error message is about the unknown 'qv' function
+    $found = pop @errs;
+    is $found->{message}{name}, 'qv', 'found the qv log';
+    is_deeply $found->{message}{location}, {
+        start => { line => 3, column => 29 },
+        end   => { line => 3, column => 30 },
+        },
+        'json log gets location of unknown function correct';
+
+    # now these are rewritten includes...
+    ( $firstinclude, $longinclude, $lastinclude ) = @{ $doc->includes };
+
+    is_deeply $firstinclude->location,
+        [ 5, 3, 3, 5, 'test-data/elem-loc.pl' ],
+        'first include stm location (after)';
+    is_deeply App::perlimports::Document::_elem_loc($firstinclude), {
+        start => { line => 5, column => 3 },
+        end   => { line => 5, column => 46 },
+        },
+        'first include stm elem_loc';
+    is_deeply $longinclude->location, [ 6, 1, 1, 6, 'test-data/elem-loc.pl' ],
+        'long include stm location (after)';
+    is_deeply App::perlimports::Document::_elem_loc($longinclude), {
+        start => { line => 6,  column => 1 },
+        end   => { line => 11, column => 2 },
+        },
+        'long include stm elem_loc';
+TODO: {
+        local $TODO = 'properly flush_locations and rebuild them';
+        is_deeply $lastinclude->location,
+            [ 12, 1, 1, 12, 'test-data/elem-loc.pl' ],
+            'last include stm location (after)';
+        is_deeply App::perlimports::Document::_elem_loc($lastinclude), {
+            start => { line => 12, column => 1 },
+            end   => { line => 12, column => 39 },
+            },
+            'last include stm elem_loc';
+    }
+};
+
+done_testing();
+

--- a/t/socket.t
+++ b/t/socket.t
@@ -135,7 +135,19 @@ subtest lint => sub {
 
     ok( !$doc->linter_success, 'fails linting' );
 
+    # TODO: empty arrayref or undef. pick one and be consistent.
+    is_deeply $doc->found_imports, {
+        'IO::Socket::INET' => undef,
+        Socket             => [qw( SO_REUSEPORT SOL_SOCKET )],
+        },
+        'found_imports indicates the latter package';
+
+    # the linting logs should indicate that -one- of the two include
+    # statements should import the symbols.  perhaps the latter one?
+
     ## no critic (ValuesAndExpressions::ProhibitImplicitNewlines)
+    TODO: {
+        local $TODO = 'fix lint logs for duplicate symbol';
     eq_or_diff(
         \@log,
         [
@@ -160,13 +172,14 @@ subtest lint => sub {
                 level   => 'error',
                 message => '@@ -5 +5 @@
 -use Socket qw(SO_REUSEPORT SOL_SOCKET);
-+use Socket ();
++use Socket qw( SO_REUSEPORT SOL_SOCKET );
 ',
             },
 
         ],
         'linting errors logged'
     );
+    }
 };
 
 done_testing;

--- a/t/socket.t
+++ b/t/socket.t
@@ -137,7 +137,7 @@ subtest lint => sub {
 
     # TODO: empty arrayref or undef. pick one and be consistent.
     is_deeply $doc->found_imports, {
-        'IO::Socket::INET' => undef,
+        'IO::Socket::INET' => [],
         Socket             => [qw( SO_REUSEPORT SOL_SOCKET )],
         },
         'found_imports indicates the latter package';
@@ -146,8 +146,6 @@ subtest lint => sub {
     # statements should import the symbols.  perhaps the latter one?
 
     ## no critic (ValuesAndExpressions::ProhibitImplicitNewlines)
-    TODO: {
-        local $TODO = 'fix lint logs for duplicate symbol';
     eq_or_diff(
         \@log,
         [
@@ -179,7 +177,6 @@ subtest lint => sub {
         ],
         'linting errors logged'
     );
-    }
 };
 
 done_testing;

--- a/t/socket.t
+++ b/t/socket.t
@@ -7,7 +7,7 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper        qw( doc logger );
-use Test::More import => [qw( done_testing is is_deeply ok subtest )];
+use Test::More import => [qw( done_testing is_deeply ok subtest $TODO )];
 
 =head1 DUPLICATE IMPORTS
 
@@ -87,6 +87,43 @@ EOF
         'found_imports indicates the latter package';
 };
 
+subtest tidy_unused => sub {
+    my ($doc) = doc(
+        filename        => 'test-data/socket.pl',
+        preserve_unused => 0,
+    );
+
+    # without preserve-unused, at least one statement should be kept.
+    # perhaps we'd prefer the latter.  for example,
+    my $expected = <<'EOF';
+use strict;
+use warnings;
+
+use Socket qw( SO_REUSEPORT SOL_SOCKET );
+
+foo( SO_REUSEPORT, SOL_SOCKET );
+sub foo { }
+EOF
+
+TODO: {
+        local $TODO = 'fix duplicate imports';
+        eq_or_diff(
+            $doc->tidied_document,
+            $expected,
+            'One include statement was excised as unused',
+        );
+    }
+
+    # TODO: the found_imports value for the "unused" package should be the
+    # same as when the preserve_unused flag is true!
+    # e.g.: empty arrayref or undef. pick one and be consistent.
+    is_deeply $doc->found_imports, {
+        'IO::Socket::INET' => undef,
+        Socket             => [qw( SO_REUSEPORT SOL_SOCKET )],
+        },
+        'found_imports indicates the latter package';
+};
+
 subtest lint => sub {
     my @log;
     my $logger = logger( \@log, 'error' );
@@ -133,3 +170,4 @@ subtest lint => sub {
 };
 
 done_testing;
+

--- a/t/socket.t
+++ b/t/socket.t
@@ -7,13 +7,62 @@ use lib 't/lib';
 
 use Test::Differences qw( eq_or_diff );
 use TestHelper        qw( doc logger );
-use Test::More import => [qw( done_testing is ok subtest )];
+use Test::More import => [qw( done_testing is is_deeply ok subtest )];
+
+=head1 DUPLICATE IMPORTS
+
+How does perl handle importing symbols of the same name from different
+packages? The answer is, perl doesn't. Exporting of symbols into other
+packages is very flexible, it all depends on the methods used for each
+package. So, the C<import> method from one package may happily overwrite
+any previously defined symbol (probably causing perl to issue a
+"redefined" warning -- you didn't turn those off, did you?), and indeed,
+this is the the behavior of L<Exporter> (a very commonly used import
+method).  However, any package may define its own C<import> method with
+different behavior (not overwriting).
+
+All of this means that, if multiple packages -could- provide an unknown
+symbol to the code under analysis, perlimports can't be certain which
+package actually provided the resulting symbol (without actually executing
+each package's C<import> method together).
+
+Our goal should be: if two modules -are- exporting the same symbol,
+regardless whether implicitly or explicitly, we should keep both include
+statements but make the symbols explicit (tidy), and log a warning (lint).
+A developer can then see (because we made it explicit) that the symbol
+appears in two places.
+
+Currently we do not do this.
+
+=head2 Test Code
+
+In this specific code under analysis "socket.pl", we are importing the
+same symbol from two packages:
+
+ use IO::Socket::INET;                    # imports 170 symbols implicitly
+ use Socket qw(SO_REUSEPORT SOL_SOCKET);  # imports 2 duplicates
+
+Now L<IO::Socket::INET> inherits from L<IO::Socket>, which has an C<import>
+method that uses C<Exporter::export> to import symbols from L<Socket> into
+its caller. When no list is specified, it imports all 170 symbols listed in
+Socket's C< @EXPORT >.
+Socket inherits its own C<import> method directly from Exporter.
+
+Exporter's C<import> method will overwrite any previously defined symbols
+(causing perl to elicit a "redefined" warning).  So the net result in this
+case is that the imported symbol definition came from the second use
+statement, package Socket.  (Of course in this case it didn't matter because
+the two packages both ultimately provided exactly the same definition.)
+
+=cut
 
 subtest tidy => sub {
     my ($doc) = doc(
         filename => 'test-data/socket.pl',
     );
 
+    # with preserve-unused (default), both use statements are kept
+    # but changed: symbols are imported from latter package.
     my $expected = <<'EOF';
 use strict;
 use warnings;
@@ -25,12 +74,17 @@ foo( SO_REUSEPORT, SOL_SOCKET );
 sub foo { }
 EOF
 
-    is(
+    eq_or_diff(
         $doc->tidied_document,
         $expected,
         'Two modules with the same exports do not get conflated'
     );
 
+    is_deeply $doc->found_imports, {
+        'IO::Socket::INET' => [],
+        Socket             => [qw( SO_REUSEPORT SOL_SOCKET )],
+        },
+        'found_imports indicates the latter package';
 };
 
 subtest lint => sub {

--- a/t/unknowns.t
+++ b/t/unknowns.t
@@ -1,0 +1,72 @@
+#!perl
+
+use strict;
+use warnings;
+
+use lib 'test-data/lib', 't/lib';
+
+use App::perlimports::Document ();
+use TestHelper                 qw( logger );
+use Test::More import => [qw( done_testing is is_deeply isa_ok subtest )];
+
+subtest 'unknown function without lint_unknowns' => sub {
+    my @log;
+
+    my $doc = App::perlimports::Document->new(
+        lint     => 1,
+        filename => 'test-data/use-constant.pm',
+        logger   => logger( \@log ),
+    );
+
+    # process the doc so that found_imports is updated to include
+    # unimported but found symbols: confess, timelocal
+    is $doc->linter_success, q{}, 'test code has lint issues';
+
+    # unknown list excludes the qualified name 'Scalar::Util::blessed', and
+    # the found (but omitted) imports 'confess' and 'timelocal'
+    my @unknown1 = @{ $doc->unknown_words };    # PPI:Token:Word
+    is scalar(@unknown1), 1, 'found only 1 unknown word';
+    my $word = shift @unknown1;
+
+    isa_ok( $word, 'PPI::Token::Word', 'unknown word' );
+    is $word->content, 'qv', 'unknown word is "qv"';
+    is_deeply $word->location,
+        [ 6, 29, 29, 6, 'test-data/use-constant.pm' ],
+        'unknown word "qv" location';
+
+    my $found = grep { $_->{message} =~ /qv/ } @log;
+    is $found, 0, 'no logs mention the unknown symbol';
+
+    $found = grep { $_->{message} =~ /Unknown function/ } @log;
+    is $found, 0, 'no logs mention unknown function';
+};
+
+subtest 'misspelled function with lint_unknowns' => sub {
+    my @log;
+
+    my $doc = App::perlimports::Document->new(
+        lint_unknowns => 1,    # implies lint => 1
+        filename      => 'test-data/lint-failure-unknowns.pl',
+        logger        => logger( \@log ),
+    );
+
+    is $doc->linter_success, q{}, 'test code has lint issues';
+
+    my @unknown = @{ $doc->unknown_words };    # PPI:Token:Word
+    my @words
+        = map { $_->isa('PPI::Token::Quote') ? $_->string : $_->content }
+        @unknown;
+
+    # unknowns do _not_ include the identified (omitted) imports:
+    # "cluck", "$QUOTE"
+    is_deeply \@words, ['is_qualified_nam'],
+        'found one unknown symbol (none of the found ones)';
+
+    my ($found)
+        = grep { $_->{message} =~ /Unknown function .is_qualified_nam/ } @log;
+    is $found && $found->{level}, 'error',
+        'lint-level log about the unknown symbol exists';
+};
+
+done_testing();
+

--- a/t/unknowns.t
+++ b/t/unknowns.t
@@ -7,7 +7,9 @@ use lib 'test-data/lib', 't/lib';
 
 use App::perlimports::Document ();
 use TestHelper                 qw( logger );
-use Test::More import => [qw( done_testing is is_deeply isa_ok subtest )];
+use Cpanel::JSON::XS           qw( decode_json );
+use Test::More import =>
+    [qw( done_testing is is_deeply isa_ok like subtest )];
 
 subtest 'unknown function without lint_unknowns' => sub {
     my @log;
@@ -66,6 +68,52 @@ subtest 'misspelled function with lint_unknowns' => sub {
         = grep { $_->{message} =~ /Unknown function .is_qualified_nam/ } @log;
     is $found && $found->{level}, 'error',
         'lint-level log about the unknown symbol exists';
+    like $found->{message}, qr/line 13/,
+        '...and it references correct line number';
+};
+
+subtest 'lint_unknowns with json mode' => sub {
+    my @log;
+
+    my $doc = App::perlimports::Document->new(
+        lint_unknowns => 1,    # implies lint => 1
+        json          => 1,
+        filename      => 'test-data/lint-failure-unknowns.pl',
+        logger        => logger( \@log ),
+    );
+
+    is $doc->linter_success, q{}, 'test code has lint issues';
+
+    # 'cluck' and '$QUOTE' are no longer unknown, because we found
+    # them when processing the includes!
+
+    my @unknown = @{ $doc->unknown_words };    # PPI:Token:Word
+    is scalar(@unknown), 1, 'found only 1 unknown word';
+    my $word = shift @unknown;
+
+    isa_ok( $word, 'PPI::Token::Word', 'unknown word' );
+    is $word->content, 'is_qualified_nam',
+        'unknown word is "is_qualified_nam"';
+    is_deeply $word->location,
+        [ 13, 24, 24, 13, 'test-data/lint-failure-unknowns.pl' ],
+        'unknown word "is_qualified_nam" location';
+
+    my ($found)
+        = grep { $_->{message} =~ /Unknown function/ } @log;
+    is $found && $found->{level}, 'error',
+        'lint-level log about the unknown symbol exists';
+    my $hash = decode_json( $found->{message} );
+    is_deeply $hash, {
+        filename  => 'test-data/lint-failure-unknowns.pl',
+        reason    => 'Unknown function',
+        name      => 'is_qualified_nam',
+        statement => 'cluck "seen it" if is_qualified_nam $args[0];',
+        location  => {
+            start => { line => 13, column => 24 },
+            end   => { line => 13, column => 39 }
+        },
+        },
+        'json log message as expected';
 };
 
 done_testing();

--- a/test-data/elem-loc.pl
+++ b/test-data/elem-loc.pl
@@ -10,6 +10,9 @@ use Getopt::Long 2.40 qw();
 my $foo = decode_json( { foo => 'bar' } );
 my @foo = GetOptions();
 
+my $bar = <<EOM;
+ some   $foo text @{[ $VERSION ]} \n\t\f pai'ge
+EOM
 script_compiles();
 script_runs();
 script_stderr_is();

--- a/test-data/elem-loc.pl
+++ b/test-data/elem-loc.pl
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use version; our $VERSION = qv('v1.0.0');
+
+  use Cpanel::JSON::XS 4.19 qw(encode_json);
+use Test::Script 1.27 qw( script_compiles script_runs
+    script_stderr_is script_stderr_like);
+use Getopt::Long 2.40 qw();
+
+my $foo = decode_json( { foo => 'bar' } );
+my @foo = GetOptions();
+
+script_compiles();
+script_runs();
+script_stderr_is();
+script_stderr_like();

--- a/test-data/lint-failure-unknowns.pl
+++ b/test-data/lint-failure-unknowns.pl
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+
+use Carp;
+use Perl::Critic::Utils qw(:classification);
+
+my %foo = (
+    $QUOTE => q{description},
+);
+
+sub croaker {
+    my @args = @_;
+    cluck "seen it" if is_qualified_nam $args[0];
+    croak "no way" unless @args == 1;
+}
+
+croaker( 7, 11 );
+

--- a/test-data/use-constant.pm
+++ b/test-data/use-constant.pm
@@ -57,3 +57,28 @@ sub new {
 
 1;
 
+__END__
+
+# this "module" is also a demonstration of how unknown symbols can bite you.
+
+$ perl -MDDP -E'require "./use-constant.pm";my $m=rfc3339::nonsense->new("26-01-04T02:17:03Z"); p$m'
+rfc3339::nonsense  {
+    public methods (11):
+        FIRST_IDX, IDX_FORMAT, IDX_SEP, IDX_SEP_RE, IDX_STR, IDX_UTIME, new
+        Carp:
+            croak
+        Time::Local:
+            timegm
+    private methods (1): _parse
+    internals: [
+        [0] undef,
+        [1] undef,
+        [2] "T",
+        [3] "T",
+        [4] "26-01-04T02:17:03Z",
+        [5] 1767493023
+    ]
+}
+$ perl -E'require "./use-constant.pm";my $m=rfc3339::nonsense->new("26-01-04T02:17:03")'
+Undefined subroutine &rfc3339::nonsense::timelocal called at ./use-constant.pm line 35.
+


### PR DESCRIPTION
This branch implements the rest of #137.  Some description of the state of this branch:

- when the PPI document (attribute of `App::perlimports::Document`) is modified during processing (`_lint_or_tidy_document`), the dependent attributes `found_imports` and `includes` will also be updated, regardless of whether we're in lint or tidy mode.
- the new feature is only enabled when giving the `--lint-unknowns` flag (which implies `--lint`, so you only have to type one of them).  If this flag is not given, there won't even be logs indicating possible trouble.  (Perhaps we should emit logs at lower level, if the flag is off?)
- (Update) Now includes a fix (and tests) for `_elem_loc` which did not correctly calculate element locations in the general case

Two outstanding topics not resolved here.

- perlimports doesn't handle duplicate imports (same symbol from multiple packages) well.  Solving this is a bit of a mess, because there is no rule saying how packages themselves handle this situation, although it seems to be typical that the last import wins (and eliciting a "redefined" warning from perl).  `perlimports` can do a lot better, as currently we [take the first one and ignore the rest](https://github.com/perl-ide/App-perlimports/blob/c918b1d6d33a75c81e2e80144956d8ba935e80b4/lib/App/perlimports/Include.pm#L323). But the end goal seems pretty clear to me. I will discuss this in another issue.  Edit: issue #145 created.
- perlimports could detect omitted packages from used qualified names, and should do _something_ about it. For example, it could insert a `use Scalar::Util ();` statement when it finds somewhere `Scalar::Util::blessed`.  Or, in lint mode (perhaps only with `lint-unknowns`) it should log an error, as implicit package dependencies are a source of fragility.

Update: I have added commits from the duplicate-imports branch that demonstrated problems described in issue #145 , and because of some changes we made here (updating the `:Document` attributes), one of the problems is resolved. But the main part of that issue remains unsolved.