### PR TITLE
Fix: Remove duplicate STDERR assertion in t/cli.t

### DIFF
--- a/t/cli.t
+++ b/t/cli.t
@@ -451,7 +451,6 @@ EOF
     my ( $stdout, $stderr ) = capture { $cli->run };
     is( $stderr, q{},       'no STDERR' );
     is( $stdout, $expected, 'stdout' );
-    is( $stderr, q{},       'no STDERR' );
 };
 
 subtest '--stdout' => sub {


### PR DESCRIPTION
Closes #154

## Summary
- Removes a redundant `is( $stderr, q{}, 'no STDERR' )` assertion in the `var-in-hash-key.pl` subtest. The first and third assertions tested the identical value with no intervening code that could modify `$stderr`, so the second check could never fail independently.

## Test plan
- [x] `prove -l t/cli.t` — all 29 subtests pass