### PR TITLE
Use bare values for simple Bool defaults in Moo attributes

### DIFF
--- a/lib/App/perlimports/Document.pm
+++ b/lib/App/perlimports/Document.pm
@@ -268,14 +268,14 @@ has _tidy_whitespace => (
     isa      => Bool,
     init_arg => 'tidy_whitespace',
     lazy     => 1,
-    default  => sub { 1 },
+    default  => 1,
 );
 
 has _verbose => (
     is       => 'ro',
     isa      => Bool,
     init_arg => 'verbose',
-    default  => sub { 0 },
+    default  => 0,
 );
 
 around BUILDARGS => sub {

--- a/lib/App/perlimports/Include.pm
+++ b/lib/App/perlimports/Include.pm
@@ -129,7 +129,7 @@ has _pad_imports => (
     is       => 'ro',
     isa      => Bool,
     init_arg => 'pad_imports',
-    default  => sub { 1 },
+    default  => 1,
 );
 
 has _tidy_whitespace => (
@@ -137,7 +137,7 @@ has _tidy_whitespace => (
     isa      => Bool,
     init_arg => 'tidy_whitespace',
     lazy     => 1,
-    default  => sub { 1 },
+    default  => 1,
 );
 
 has _will_never_export => (


### PR DESCRIPTION
Closes #155

## Summary
- Replace `default => sub { 1 }` / `default => sub { 0 }` with bare `default => 1` / `default => 0` for `Bool` attributes in `Include.pm` (`_pad_imports`, `_tidy_whitespace`) and `Document.pm` (`_tidy_whitespace`, `_verbose`).
- Moo treats the two forms as functionally identical for non-reference defaults; using the bare form consistently is shorter and matches Moo's recommendation.
- Purely cosmetic — no behavior change, so no new tests.

## Test plan
- [x] `prove -lr -j2 t` passes (89 files, 217 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)