### PR TITLE
Silence warnings inside Sandbox eval_pkg probes

### DIFF
--- a/lib/App/perlimports/Sandbox.pm
+++ b/lib/App/perlimports/Sandbox.pm
@@ -37,6 +37,14 @@ EOF
 
     ## no critic (Variables::RequireInitializationForLocalVars)
     local $@;
+
+    # Suppress warnings emitted while probing. Callers only inspect $@ to
+    # decide whether the eval compiled, so stray warnings (e.g. "Attempt to
+    # call undefined import method" when probing OO-only modules like
+    # LWP::UserAgent with an import list) would otherwise leak to STDERR
+    # during normal runs and pollute `dzil test` output.
+    local $SIG{__WARN__} = sub { };
+
     ## no critic (BuiltinFunctions::ProhibitStringyEval,ErrorHandling::RequireCheckingReturnValueOfEval)
     eval $to_eval;
 


### PR DESCRIPTION
## Summary

- `Sandbox::eval_pkg` probes each `use` statement to check whether it compiles; for OO-only modules like `LWP::UserAgent` this emits `Attempt to call undefined import method with arguments ("new") via package "LWP::UserAgent"` to STDERR during `dzil test`.
- Callers only inspect `$@` (per the documented contract), so warnings are noise. Install `local $SIG{__WARN__} = sub { };` around the `eval` so the probe stays silent.

## Test plan

- [ ] `dzil test` no longer emits the `Attempt to call undefined import method` warning
- [ ] `prove -lr -j2 t` still passes (notably `t/Sandbox.t`, `t/never-exports.t`, `t/method.t`, `t/require.t`, `t/with-version.t`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>